### PR TITLE
feat: add  notification channel 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 .idea/
+coverage/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,34 +22,3 @@ crossbeam = "0.8"
 lazy_static = "1.4"
 rusty_pool = { version = "0.7" }
 
-# [[bin]]
-# name = "calc_basic"
-# path = "examples/calc_basic.rs"
-
-# [[bin]]
-# name = "calc_fn_basic"
-# path = "examples/calc_fn_basic.rs"
-
-# [[bin]]
-# name = "calc_concurrent"
-# path = "examples/calc_concurrent.rs"
-
-# [[bin]]
-# name = "calc_unsubscribe"
-# path = "examples/calc_unsubscribe.rs"
-
-# [[bin]]
-# name = "calc_clear_subscriber"
-# path = "examples/calc_clear_subscribers.rs"
-
-# [[bin]]
-# name = "calc_thunk"
-# path = "examples/calc_thunk.rs"
-
-# [[bin]]
-# name = "calc_effect"
-# path = "examples/calc_effect.rs"
-
-# [[bin]]
-# name = "calc_basic_builder"
-# path = "examples/calc_basic_builder.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,10 @@ keywords = ["redux", "store", "rust", "state", "management"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-dev = []
+notify-channel = []
 
 [dependencies]
 thiserror = "1.0.58"
 crossbeam = "0.8"
-lazy_static = "1.4"
 rusty_pool = { version = "0.7" }
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ help:  ## show this help
 	@cat $(MAKEFILE_LIST) | grep -E "^[a-zA-Z0-9_-]+:.*?## .*$$" | \
     awk 'BEGIN {FS = ":.*?# "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+setup:	## setup
+	cargo install cargo-tarpaulin
+
 build:	## build
 	cargo build --lib
 
@@ -22,11 +25,32 @@ test:	## test
 test-dev:	## test for development
 	RUST_TEST_THREADS=1 RUST_LOG=debug cargo test --features dev  -- --nocapture
 
+.PHONY: test-cov
+test-cov:	## Run test coverage using tarpaulin
+	cargo tarpaulin --verbose --all-features --workspace --timeout 120 \
+		--out Html --output-dir coverage \
+		--exclude-files "examples/*"
+
+
+.PHONY: test-cov-open
+test-cov-open: test-cov	## Run test coverage and open the report
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+		open coverage/tarpaulin-report.html; \
+	elif [ "$(shell uname)" = "Linux" ]; then \
+		xdg-open coverage/tarpaulin-report.html; \
+	fi
+
+.PHONY: lint
+lint:	## lint
+	cargo clippy
+
+.PHONY: fmt
+fmt: ## format
+	cargo fmt
 
 .PHONY: doc
 doc:	## doc
 	cargo doc --lib --no-deps -p rs-store
-
 
 example-calc:	## example calc_basic
 	cargo run --example calc_basic

--- a/Makefile
+++ b/Makefile
@@ -12,25 +12,34 @@ build:	## build
 	cargo build --lib
 
 build-dev: ## build for development
-	cargo build --lib --features dev
+	cargo build --lib --profile dev
+
+build-full: ## build for release
+	cargo build --lib --features full
+
 
 clean:	## clean
 	cargo clean
 
 .PHONY: test
 test:	## test
-	cargo test
+	RUST_TEST_THREADS=1 RUST_LOG=debug cargo test
+
+test-all: test-dev test-notify-channel ## test with full features
 
 .PHONY: test-dev
-test-dev:	## test for development
-	RUST_TEST_THREADS=1 RUST_LOG=debug cargo test --features dev  -- --nocapture
+test-dev:	## test with log
+	RUST_TEST_THREADS=1 RUST_LOG=debug cargo test --profile dev  -- --nocapture
+
+.PHONY: test-notify-channel
+test-notify-channel:	## test with notify-channel
+	RUST_TEST_THREADS=1 RUST_LOG=debug cargo test --profile dev  --features notify-channel -- --nocapture
 
 .PHONY: test-cov
 test-cov:	## Run test coverage using tarpaulin
 	cargo tarpaulin --verbose --all-features --workspace --timeout 120 \
 		--out Html --output-dir coverage \
 		--exclude-files "examples/*"
-
 
 .PHONY: test-cov-open
 test-cov-open: test-cov	## Run test coverage and open the report

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ rs-store provides a predictable state container inspired by Redux, featuring thr
 - 🧪 Comprehensive test coverage
 - 📚 Selector support
 - 📊 Metrics support
+- 🔄 Decoupling state updates from notification delivery
 
 ## Installation
 
@@ -30,6 +31,13 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 rs-store = "0.18.2"
+```
+
+with the `notify-channel` feature:
+
+```toml
+[dependencies]
+rs-store = { version = "0.18.2", features = ["notify-channel"] }
 ```
 
 ## Quick Start
@@ -91,6 +99,16 @@ Unlike traditional Redux implementations, rs-store allows reducers to produce si
 
 This design choice provides more flexibility while maintaining predictable state management.
 
+## Notification Channel feature
+
+The notification channel feature provides a dedicated channel for state notifications to subscribers, separating the concerns of state updates and notification delivery. This can help improve performance and reliability by:
+
+- Decoupling state updates from notification delivery
+- Preventing slow subscribers from blocking state updates
+- Allowing independent backpressure handling for notifications
+- Supporting different threading models for notification delivery
+
+
 ## Documentation
 
 For detailed documentation, visit:
@@ -102,7 +120,7 @@ For detailed documentation, visit:
 
 ### In Progress 🚧
 - Latest state notification for new subscribers
-- Notification scheduler (CurrentThread, ThreadPool)
+- [x] Notification scheduler (CurrentThread, ThreadPool)
 - Stream-based pull model
 
 ## Contributing

--- a/examples/calc_basic.rs
+++ b/examples/calc_basic.rs
@@ -1,7 +1,7 @@
-use std::sync::{Arc, Mutex};
-use std::thread;
 use rs_store::{DispatchOp, Dispatcher};
 use rs_store::{Reducer, Store, Subscriber};
+use std::sync::{Arc, Mutex};
+use std::thread;
 
 #[derive(Debug, Clone)]
 enum CalcAction {
@@ -72,13 +72,17 @@ impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
             CalcAction::Add(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: state:{:?} <- last {:?} + action:{:?}",
-                    state, self.last.lock().unwrap(), action
+                    state,
+                    self.last.lock().unwrap(),
+                    action
                 );
             }
             CalcAction::Subtract(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: state:{:?} <- last {:?} + action:{:?}",
-                    state, self.last.lock().unwrap(), action
+                    state,
+                    self.last.lock().unwrap(),
+                    action
                 );
             }
         }

--- a/examples/calc_basic_builder.rs
+++ b/examples/calc_basic_builder.rs
@@ -94,7 +94,7 @@ impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
 pub fn main() {
     println!("Hello, Builder!");
 
-    let store = StoreBuilder::new(Box::new(CalcReducer::default()))
+    let store = StoreBuilder::new_with_reducer(Box::new(CalcReducer::default()))
         .with_name("calc".to_string())
         .build()
         .unwrap();

--- a/examples/calc_clear_subscribers.rs
+++ b/examples/calc_clear_subscribers.rs
@@ -83,13 +83,19 @@ impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
             CalcAction::Add(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
-                    self.id, state, self.last.lock().unwrap(), action,
+                    self.id,
+                    state,
+                    self.last.lock().unwrap(),
+                    action,
                 );
             }
             CalcAction::Subtract(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
-                    self.id, state, self.last.lock().unwrap(), action,
+                    self.id,
+                    state,
+                    self.last.lock().unwrap(),
+                    action,
                 );
             }
         }

--- a/examples/calc_fn_basic.rs
+++ b/examples/calc_fn_basic.rs
@@ -50,10 +50,7 @@ fn calc_subscriber(state: &CalcState, action: &CalcAction) {
             println!("CalcSubscriber::on_notify: state:{:?}, action:{}", state, i);
         }
         CalcAction::Subtract(i) => {
-            println!(
-                "CalcSubscriber::on_notify: state:{:?}, action:{}",
-                state, i
-            );
+            println!("CalcSubscriber::on_notify: state:{:?}, action:{}", state, i);
         }
     }
 }

--- a/examples/calc_thunk.rs
+++ b/examples/calc_thunk.rs
@@ -83,13 +83,19 @@ impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
             CalcAction::Add(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
-                    self.id, state, self.last.lock().unwrap(), action,
+                    self.id,
+                    state,
+                    self.last.lock().unwrap(),
+                    action,
                 );
             }
             CalcAction::Subtract(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
-                    self.id, state, self.last.lock().unwrap(), action,
+                    self.id,
+                    state,
+                    self.last.lock().unwrap(),
+                    action,
                 );
             }
         }

--- a/examples/calc_unsubscribe.rs
+++ b/examples/calc_unsubscribe.rs
@@ -83,13 +83,19 @@ impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
             CalcAction::Add(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
-                    self.id, state, self.last.lock().unwrap(), action,
+                    self.id,
+                    state,
+                    self.last.lock().unwrap(),
+                    action,
                 );
             }
             CalcAction::Subtract(_i) => {
                 println!(
                     "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
-                    self.id, state, self.last.lock().unwrap(), action,
+                    self.id,
+                    state,
+                    self.last.lock().unwrap(),
+                    action,
                 );
             }
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,7 +20,7 @@ where
     capacity: usize,
     policy: BackpressurePolicy,
     middlewares: Vec<Arc<Mutex<dyn Middleware<State, Action> + Send + Sync>>>,
-    metrics: Option<Arc<dyn StoreMetrics<State, Action> + Send + Sync>>,
+    metrics: Option<Arc<dyn StoreMetrics<Action> + Send + Sync>>,
 }
 
 impl<State, Action> Default for StoreBuilder<State, Action>
@@ -46,7 +46,19 @@ where
     State: Default + Send + Sync + Clone + 'static,
     Action: Send + Sync + Clone + 'static,
 {
-    pub fn new(reducer: Box<dyn Reducer<State, Action> + Send + Sync>) -> Self {
+    pub fn new() -> Self {
+        StoreBuilder {
+            name: "store".to_string(),
+            state: Default::default(),
+            reducers: vec![],
+            capacity: DEFAULT_CAPACITY,
+            policy: Default::default(),
+            middlewares: Vec::new(),
+            metrics: None,
+        }
+    }
+
+    pub fn new_with_reducer(reducer: Box<dyn Reducer<State, Action> + Send + Sync>) -> Self {
         StoreBuilder {
             name: "store".to_string(),
             state: Default::default(),
@@ -120,10 +132,7 @@ where
         self
     }
 
-    pub fn with_metrics(
-        mut self,
-        metrics: Arc<dyn StoreMetrics<State, Action> + Send + Sync>,
-    ) -> Self {
+    pub fn with_metrics(mut self, metrics: Arc<dyn StoreMetrics<Action> + Send + Sync>) -> Self {
         self.metrics = Some(metrics);
         self
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,7 +20,7 @@ where
     capacity: usize,
     policy: BackpressurePolicy,
     middlewares: Vec<Arc<Mutex<dyn Middleware<State, Action> + Send + Sync>>>,
-    metrics: Option<Arc<dyn StoreMetrics<Action> + Send + Sync>>,
+    metrics: Option<Arc<dyn StoreMetrics + Send + Sync>>,
 }
 
 impl<State, Action> Default for StoreBuilder<State, Action>
@@ -132,7 +132,7 @@ where
         self
     }
 
-    pub fn with_metrics(mut self, metrics: Arc<dyn StoreMetrics<Action> + Send + Sync>) -> Self {
+    pub fn with_metrics(mut self, metrics: Arc<dyn StoreMetrics + Send + Sync>) -> Self {
         self.metrics = Some(metrics);
         self
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -56,8 +56,8 @@ where
                     // Remove the oldest item
                     let _old = self.receiver.try_recv();
                     if let Some(metrics) = &self.metrics {
-                        match _old {
-                            Ok(ActionOp::Action(&action)) => metrics.action_dropped(Some(action)),
+                        match _old.as_ref() {
+                            Ok(ActionOp::Action(action)) => metrics.action_dropped(Some(action)),
                             _ => {}
                         }
                     }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -23,7 +23,7 @@ where
     Action: Send + Sync + Clone + 'static,
 {
     fn dispatch(&self, action: Action) {
-        let sender = self.tx.lock().unwrap();
+        let sender = self.dispatch_tx.lock().unwrap();
         if let Some(tx) = sender.as_ref() {
             let _ = tx.send(ActionOp::Action(action)).unwrap_or(0);
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,29 +7,21 @@ use std::{fmt, sync::atomic::AtomicUsize, time::Duration};
 /// StoreMetrics is a trait for metrics that can be used to track the state of the store.
 #[allow(dead_code)]
 #[allow(unused_variables)]
-pub trait StoreMetrics<State, Action>: Send + Sync
+pub trait StoreMetrics<T>: Send + Sync
 where
-    State: Send + Sync + 'static,
-    Action: Send + Sync + Clone + 'static,
+    T: Send + Sync + 'static,
 {
     /// action_received is called when an action is received.
-    fn action_received(&self, action: &Action) {}
+    fn action_received(&self, data: Option<&T>) {}
     /// action_dropped is called when an action is dropped.
-    fn action_dropped(&self, action: &Action) {}
+    fn action_dropped(&self, data: Option<&T>) {}
 
     /// middleware_execution_time is called when a middleware is executed,
     /// it includes the time spent of reducing the action and the time spent in the middleware
-    fn middleware_executed(&self, action: &Action, middleware_name: &str, duration: Duration) {}
+    fn middleware_executed(&self, data: Option<&T>, middleware_name: &str, duration: Duration) {}
 
     /// action_reduced is called when an action is reduced.
-    fn action_reduced(
-        &self,
-        action: &Action,
-        old_state: &State,
-        new_state: &State,
-        duration: Duration,
-    ) {
-    }
+    fn action_reduced(&self, data: Option<&T>, duration: Duration) {}
 
     /// effect_issued is called when the number of effects issued.
     fn effect_issued(&self, count: usize) {}
@@ -38,7 +30,7 @@ where
     fn effect_executed(&self, count: usize, duration: Duration) {}
 
     /// subscriber_notified is called when a subscriber is notified.
-    fn subscriber_notified(&self, action: &Action, count: usize, duration: Duration) {}
+    fn subscriber_notified(&self, data: Option<&T>, count: usize, duration: Duration) {}
 
     /// queue_size is called when the remaining queue is changed.
     fn queue_size(&self, current_size: usize) {}
@@ -50,12 +42,7 @@ where
 /// NoOpMetrics is a no-op implementation of StoreMetrics.
 pub struct NoOpMetrics;
 
-impl<State, Action> StoreMetrics<State, Action> for NoOpMetrics
-where
-    State: Send + Sync + 'static,
-    Action: Send + Sync + Clone + 'static,
-{
-}
+impl<T> StoreMetrics<T> for NoOpMetrics where T: Send + Sync + Clone + 'static {}
 
 pub struct CountMetrics {
     /// total number of actions received
@@ -238,19 +225,18 @@ impl CountMetrics {
 }
 
 #[allow(unused_variables)]
-impl<State, Action> StoreMetrics<State, Action> for CountMetrics
+impl<T> StoreMetrics<T> for CountMetrics
 where
-    State: Send + Sync + 'static,
-    Action: Send + Sync + Clone + 'static,
+    T: Send + Sync + Clone + 'static,
 {
-    fn action_received(&self, _action: &Action) {
+    fn action_received(&self, data: Option<&T>) {
         self.action_received.fetch_add(1, Ordering::SeqCst);
     }
-    fn action_dropped(&self, _action: &Action) {
+    fn action_dropped(&self, data: Option<&T>) {
         self.action_dropped.fetch_add(1, Ordering::SeqCst);
     }
 
-    fn middleware_executed(&self, _action: &Action, _middleware_name: &str, duration: Duration) {
+    fn middleware_executed(&self, data: Option<&T>, _middleware_name: &str, duration: Duration) {
         let duration_ms = duration.as_millis() as usize;
         if duration_ms > self.middleware_time_max.load(Ordering::SeqCst) {
             self.middleware_time_max.store(duration_ms, Ordering::SeqCst);
@@ -261,13 +247,7 @@ where
         self.middleware_execution_time.fetch_add(duration_ms, Ordering::SeqCst);
     }
 
-    fn action_reduced(
-        &self,
-        _action: &Action,
-        _old_state: &State,
-        _new_state: &State,
-        duration: Duration,
-    ) {
+    fn action_reduced(&self, data: Option<&T>, duration: Duration) {
         self.action_reduced.fetch_add(1, Ordering::SeqCst);
         let duration_ms = duration.as_millis() as usize;
         if duration_ms > self.reducer_time_max.load(Ordering::SeqCst) {
@@ -287,7 +267,7 @@ where
         //self.effect_executed.fetch_add(1, Ordering::SeqCst);
     }
 
-    fn subscriber_notified(&self, _action: &Action, _count: usize, duration: Duration) {
+    fn subscriber_notified(&self, data: Option<&T>, _count: usize, duration: Duration) {
         self.subscriber_notified.fetch_add(1, Ordering::SeqCst);
         let duration_ms = duration.as_millis() as usize;
         if duration_ms > self.subscriber_time_max.load(Ordering::SeqCst) {
@@ -379,7 +359,8 @@ mod tests {
         // let metrics: Arc<Box<dyn StoreMetrics<i32, i32> + Send + Sync>> =
         //     Arc::new(Box::new(CountMetrics::default()));
         let metrics = CountMetrics::new();
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_capacity(5)
             .with_policy(BackpressurePolicy::DropOldest)
             .with_metrics(metrics.clone())
@@ -407,7 +388,8 @@ mod tests {
     fn test_count_metrics_with_dropped_actions() {
         // given
         let metrics = CountMetrics::new();
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_capacity(2)
             .with_policy(BackpressurePolicy::DropOldest)
             .with_metrics(metrics.clone())
@@ -433,7 +415,8 @@ mod tests {
         // given
         let metrics = CountMetrics::new();
         let middleware = Arc::new(Mutex::new(TestMiddleware::new("test")));
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_capacity(5)
             .with_middleware(middleware)
             .with_metrics(metrics.clone())

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_logger_middleware() {
         let reducer = Box::new(TestReducer);
-        let store_result = StoreBuilder::new(reducer).build();
+        let store_result = StoreBuilder::new_with_reducer(reducer).build();
 
         assert!(store_result.is_ok());
 
@@ -339,7 +339,7 @@ mod tests {
     fn test_middleware_before_reduce() {
         // given
         let reducer = Box::new(MiddlewareReducer::new());
-        let store_result = StoreBuilder::new(reducer).build();
+        let store_result = StoreBuilder::new_with_reducer(reducer).build();
         assert!(store_result.is_ok());
         let store = store_result.unwrap();
 
@@ -471,7 +471,7 @@ mod tests {
     fn test_effect_middleware() {
         // given
         let reducer = Box::new(EffectReducer::new());
-        let store_result = StoreBuilder::new(reducer).build();
+        let store_result = StoreBuilder::new_with_reducer(reducer).build();
         assert!(store_result.is_ok());
 
         // when

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -88,7 +88,7 @@ mod tests {
 
         // Create store with our test reducer
         let reducer = Box::new(PanicOnValueReducer { panic_on: 42 });
-        let store = StoreBuilder::new(reducer).build().unwrap();
+        let store = StoreBuilder::new_with_reducer(reducer).build().unwrap();
 
         // Track state changes
         let state_changes = Arc::new(Mutex::new(Vec::new()));
@@ -150,7 +150,8 @@ mod tests {
         }
 
         // Create store with both reducers
-        let store = StoreBuilder::new(Box::new(PanicReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(PanicReducer))
             .add_reducer(Box::new(NormalReducer))
             .build()
             .unwrap();

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,5 +1,6 @@
 /// Selector is a function that selects a part of the state.
 pub trait Selector<State, Output> {
+    /// Selects a part of the state.
     fn select(&self, state: &State) -> Output;
 }
 
@@ -10,8 +11,8 @@ where
     State: Default + Send + Sync + Clone,
     Output: Send + Sync + Clone,
 {
-    func: F,
-    _marker: std::marker::PhantomData<(State, Output)>,
+    func: Box<dyn Fn(&State) -> Output>,
+    _marker: std::marker::PhantomData<F>,
 }
 
 impl<F, State, Output> Selector<State, Output> for FnSelector<F, State, Output>
@@ -22,5 +23,37 @@ where
 {
     fn select(&self, state: &State) -> Output {
         (self.func)(state)
+    }
+}
+
+impl<F, State, Output> From<F> for FnSelector<F, State, Output>
+where
+    F: Fn(&State) -> Output + 'static,
+    State: Default + Send + Sync + Clone,
+    Output: Send + Sync + Clone,
+{
+    fn from(func: F) -> Self {
+        Self {
+            func: Box::new(func),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default, Clone)]
+    struct State {
+        a: i32,
+    }
+
+    #[test]
+    fn test_selector() {
+        let selector = FnSelector::from(|state: &State| state.a);
+        let state = State { a: 1 };
+        let output = selector.select(&state);
+        assert_eq!(output, 1);
     }
 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -55,6 +55,8 @@ where
 }
 
 /// SelectorSubscriber is a subscriber that has a selector.
+/// It is used to subscribe to a specific part of the state.
+/// when the state changes, the selector subscriber will notify the subscriber.
 pub struct SelectorSubscriber<State, Action, Select, Output>
 where
     State: Default + Send + Sync + Clone,

--- a/src/test_mock.rs
+++ b/src/test_mock.rs
@@ -229,7 +229,8 @@ mod tests {
     fn test_mock_subscriber() {
         // given
         let mock_subscriber = Arc::new(MockSubscriber::new());
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_name("test_store".to_string())
             .build()
             .unwrap();
@@ -255,7 +256,8 @@ mod tests {
             },
         ));
 
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_name("test_store".to_string())
             .build()
             .unwrap();
@@ -275,7 +277,8 @@ mod tests {
         // given
         let mock_middleware = Arc::new(Mutex::new(MockMiddleware::new()));
 
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_name("test_store".to_string())
             .with_middleware(mock_middleware.clone())
             .build()
@@ -318,7 +321,8 @@ mod tests {
             });
         }
 
-        let store = StoreBuilder::new(Box::new(TestReducer))
+        let store = StoreBuilder::new()
+            .with_reducer(Box::new(TestReducer))
             .with_name("test_store".to_string())
             .with_middleware(mock_middleware.clone())
             .build()


### PR DESCRIPTION
The notification channel feature provides a dedicated channel for state notifications to subscribers, separating the concerns of state updates and notification delivery. This can help improve performance and reliability by:

- Decoupling state updates from notification delivery
- Preventing slow subscribers from blocking state updates
- Allowing independent backpressure handling for notifications
- Supporting different threading models for notification delivery