### PR TITLE
feat: implement latest state notification for new subscribers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ add_tag:	## add tag
 	git tag -a "v$(VERSION)" -m "v$(VERSION)"
 
 .PHONY: publish
-publish: check_version_tag build publish_cargo add_tag	## publish
+publish: check_version_tag build test-all publish_cargo add_tag	## publish
 	@echo "published v$(VERSION)"
 	@echo push tag v$(VERSION) to origin
 	@git push origin v$(VERSION)

--- a/examples/calc_new_subscriber.rs
+++ b/examples/calc_new_subscriber.rs
@@ -1,0 +1,170 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use rs_store::{DispatchOp, StoreBuilder};
+use rs_store::{Reducer, Subscriber};
+
+#[derive(Debug, Clone)]
+enum CalcAction {
+    Add(i32),
+    Subtract(i32),
+}
+
+struct CalcReducer {}
+
+impl Default for CalcReducer {
+    fn default() -> CalcReducer {
+        CalcReducer {}
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CalcState {
+    count: i32,
+}
+
+impl Default for CalcState {
+    fn default() -> CalcState {
+        CalcState { count: 0 }
+    }
+}
+
+impl Reducer<CalcState, CalcAction> for CalcReducer {
+    fn reduce(&self, state: &CalcState, action: &CalcAction) -> DispatchOp<CalcState, CalcAction> {
+        match action {
+            CalcAction::Add(i) => {
+                println!("CalcReducer::reduce: + {}", i);
+                DispatchOp::Dispatch(
+                    CalcState {
+                        count: state.count + i,
+                    },
+                    None,
+                )
+            }
+            CalcAction::Subtract(i) => {
+                println!("CalcReducer::reduce: - {}", i);
+                DispatchOp::Dispatch(
+                    CalcState {
+                        count: state.count - i,
+                    },
+                    None,
+                )
+            }
+        }
+    }
+}
+
+// 새로운 subscriber가 추가될 때 최신 상태를 받는 subscriber
+struct CalcSubscriberWithSubscribe {
+    id: i32,
+    last: Mutex<CalcState>,
+    subscribe_called: Mutex<bool>,
+    subscribe_state: Mutex<Option<CalcState>>,
+}
+
+impl CalcSubscriberWithSubscribe {
+    fn new(id: i32) -> Self {
+        Self {
+            id,
+            last: Mutex::new(CalcState::default()),
+            subscribe_called: Mutex::new(false),
+            subscribe_state: Mutex::new(None),
+        }
+    }
+
+    fn was_subscribe_called(&self) -> bool {
+        *self.subscribe_called.lock().unwrap()
+    }
+
+    fn get_subscribe_state(&self) -> Option<CalcState> {
+        self.subscribe_state.lock().unwrap().clone()
+    }
+}
+
+impl Subscriber<CalcState, CalcAction> for CalcSubscriberWithSubscribe {
+    fn on_subscribe(&self, state: &CalcState) {
+        println!(
+            "CalcSubscriber::on_subscribe: id:{}, received initial state: {:?}",
+            self.id, state
+        );
+        *self.subscribe_called.lock().unwrap() = true;
+        *self.subscribe_state.lock().unwrap() = Some(state.clone());
+        *self.last.lock().unwrap() = state.clone();
+    }
+
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
+        println!(
+            "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
+            self.id,
+            state,
+            self.last.lock().unwrap(),
+            action,
+        );
+
+        *self.last.lock().unwrap() = state.clone();
+    }
+}
+
+pub fn main() {
+    println!("Hello, New Subscriber with Latest State!");
+
+    let store =
+        StoreBuilder::new_with_reducer(CalcState::default(), Box::new(CalcReducer::default()))
+            .with_name("calc-new-subscriber".into())
+            .build()
+            .unwrap();
+
+    // 첫 번째 subscriber 추가
+    println!("=== Adding first subscriber ===");
+    let subscriber1 = Arc::new(CalcSubscriberWithSubscribe::new(1));
+    store.add_subscriber(subscriber1.clone());
+
+    // 액션을 dispatch하여 상태 변경
+    println!("=== Dispatching actions ===");
+    store.dispatch(CalcAction::Add(5)).unwrap();
+    store.dispatch(CalcAction::Add(10)).unwrap();
+
+    // 잠시 대기하여 액션이 처리되도록 함
+    thread::sleep(std::time::Duration::from_millis(100));
+
+    // 두 번째 subscriber 추가 (현재 상태는 count: 15)
+    println!("=== Adding second subscriber ===");
+    let subscriber2 = Arc::new(CalcSubscriberWithSubscribe::new(2));
+    store.add_subscriber(subscriber2.clone());
+
+    // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
+    thread::sleep(std::time::Duration::from_millis(100));
+
+    // 새로운 액션을 dispatch
+    println!("=== Dispatching more actions ===");
+    store.dispatch(CalcAction::Subtract(3)).unwrap();
+    store.dispatch(CalcAction::Add(7)).unwrap();
+
+    // 잠시 대기하여 액션이 처리되도록 함
+    thread::sleep(std::time::Duration::from_millis(100));
+
+    // 결과 확인
+    println!("=== Results ===");
+    println!("Final state: {:?}", store.get_state());
+
+    // 첫 번째 subscriber 확인
+    println!("Subscriber 1:");
+    println!("  Subscribe called: {}", subscriber1.was_subscribe_called());
+    if let Some(state) = subscriber1.get_subscribe_state() {
+        println!("  Initial state received: {:?}", state);
+    }
+    println!("  Last state: {:?}", *subscriber1.last.lock().unwrap());
+
+    // 두 번째 subscriber 확인
+    println!("Subscriber 2:");
+    println!("  Subscribe called: {}", subscriber2.was_subscribe_called());
+    if let Some(state) = subscriber2.get_subscribe_state() {
+        println!("  Initial state received: {:?}", state);
+    }
+    println!("  Last state: {:?}", *subscriber2.last.lock().unwrap());
+
+    // stop the store
+    store.stop();
+
+    println!("Done!");
+}

--- a/examples/dropoldest_if.rs
+++ b/examples/dropoldest_if.rs
@@ -8,6 +8,7 @@ fn main() {
         match action_op {
             rs_store::ActionOp::Action(value) => *value < 5, // 5보다 작은 값들은 drop
             rs_store::ActionOp::Exit(_) => false,            // Exit는 drop하지 않음
+            rs_store::ActionOp::AddSubscriber => false,      // AddSubscriber는 drop하지 않음
         }
     });
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -79,19 +79,19 @@ where
         eprintln!("store: StateIterator next");
 
         if let Some(iter_rx) = self.iter_rx.as_ref() {
-            match iter_rx.recv() {
-                Some(ActionOp::Action((state, action))) => return Some((state, action)),
-                Some(ActionOp::Exit(_)) => {
-                    #[cfg(feature = "store-log")]
-                    eprintln!("store: StateIterator exit");
-                    // fall through
+            while let Some(action) = iter_rx.recv() {
+                match action {
+                    ActionOp::Action((state, action)) => return Some((state, action)),
+                    ActionOp::Exit(_) => {
+                        #[cfg(feature = "store-log")]
+                        eprintln!("store: StateIterator exit");
+                        break;
+                    }
+                    ActionOp::AddSubscriber => {
+                        continue;
+                    }
                 }
-                None => {
-                    #[cfg(feature = "store-log")]
-                    eprintln!("store: StateIterator error");
-                    // fall through
-                }
-            };
+            }
         };
 
         if let Some(subscription) = self.subscription.take() {

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -4,6 +4,10 @@ where
     State: Send + Sync + Clone,
     Action: Send + Sync + Clone,
 {
+    /// on_subscribe is called when the subscriber is subscribed to the store.
+    #[allow(unused_variables)]
+    fn on_subscribe(&self, state: &State) {}
+
     /// on_notify is called when the store is notified of an action.
     fn on_notify(&self, state: &State, action: &Action);
 
@@ -55,6 +59,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[allow(dead_code)]
     // 테스트용 상태 구조체
@@ -71,5 +77,197 @@ mod tests {
         IncrementCounter,
         #[allow(dead_code)]
         SetName(String),
+    }
+
+    // 새로운 subscriber가 추가될 때 최신 상태를 받는지 테스트하는 subscriber
+    struct TestSubscriberWithSubscribe {
+        received_states: Arc<Mutex<Vec<TestState>>>,
+        received_actions: Arc<Mutex<Vec<TestAction>>>,
+        subscribe_called: Arc<Mutex<bool>>,
+    }
+
+    impl TestSubscriberWithSubscribe {
+        fn new() -> Self {
+            Self {
+                received_states: Arc::new(Mutex::new(Vec::new())),
+                received_actions: Arc::new(Mutex::new(Vec::new())),
+                subscribe_called: Arc::new(Mutex::new(false)),
+            }
+        }
+
+        fn get_received_states(&self) -> Vec<TestState> {
+            self.received_states.lock().unwrap().clone()
+        }
+
+        fn get_received_actions(&self) -> Vec<TestAction> {
+            self.received_actions.lock().unwrap().clone()
+        }
+
+        fn was_subscribe_called(&self) -> bool {
+            *self.subscribe_called.lock().unwrap()
+        }
+    }
+
+    impl Subscriber<TestState, TestAction> for TestSubscriberWithSubscribe {
+        fn on_subscribe(&self, state: &TestState) {
+            // 새로운 subscriber가 추가될 때 최신 상태를 받음
+            self.received_states.lock().unwrap().push(state.clone());
+            *self.subscribe_called.lock().unwrap() = true;
+        }
+
+        fn on_notify(&self, state: &TestState, action: &TestAction) {
+            // 액션이 발생할 때마다 상태와 액션을 받음
+            self.received_states.lock().unwrap().push(state.clone());
+            self.received_actions.lock().unwrap().push(action.clone());
+        }
+    }
+
+    #[test]
+    fn test_subscriber_on_subscribe() {
+        let subscriber = TestSubscriberWithSubscribe::new();
+        let state = TestState {
+            counter: 42,
+            name: "test".to_string(),
+        };
+
+        // on_subscribe 호출
+        subscriber.on_subscribe(&state);
+
+        // 검증
+        assert!(subscriber.was_subscribe_called());
+        let received_states = subscriber.get_received_states();
+        assert_eq!(received_states.len(), 1);
+        assert_eq!(received_states[0].counter, 42);
+        assert_eq!(received_states[0].name, "test");
+    }
+
+    #[test]
+    fn test_subscriber_on_notify() {
+        let subscriber = TestSubscriberWithSubscribe::new();
+        let state = TestState {
+            counter: 100,
+            name: "notify".to_string(),
+        };
+        let action = TestAction::IncrementCounter;
+
+        // on_notify 호출
+        subscriber.on_notify(&state, &action);
+
+        // 검증
+        let received_states = subscriber.get_received_states();
+        let received_actions = subscriber.get_received_actions();
+        assert_eq!(received_states.len(), 1);
+        assert_eq!(received_actions.len(), 1);
+        assert_eq!(received_states[0].counter, 100);
+        assert_eq!(received_states[0].counter, 100);
+        assert_eq!(received_states[0].name, "notify");
+    }
+
+    // FnSubscriber 테스트
+    #[test]
+    fn test_fn_subscriber() {
+        let received_states = Arc::new(Mutex::new(Vec::new()));
+        let received_actions = Arc::new(Mutex::new(Vec::new()));
+
+        let fn_subscriber = FnSubscriber::from(|state: &TestState, action: &TestAction| {
+            received_states.lock().unwrap().push(state.clone());
+            received_actions.lock().unwrap().push(action.clone());
+        });
+
+        let state = TestState {
+            counter: 42,
+            name: "test".to_string(),
+        };
+        let action = TestAction::IncrementCounter;
+
+        // on_notify 호출
+        fn_subscriber.on_notify(&state, &action);
+
+        // 검증
+        let states = received_states.lock().unwrap();
+        let actions = received_actions.lock().unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(states[0].counter, 42);
+        assert_eq!(states[0].name, "test");
+    }
+
+    // 여러 번의 on_subscribe 호출 테스트
+    #[test]
+    fn test_multiple_on_subscribe_calls() {
+        let subscriber = TestSubscriberWithSubscribe::new();
+        let state1 = TestState {
+            counter: 10,
+            name: "first".to_string(),
+        };
+        let state2 = TestState {
+            counter: 20,
+            name: "second".to_string(),
+        };
+
+        // 첫 번째 on_subscribe 호출
+        subscriber.on_subscribe(&state1);
+        assert!(subscriber.was_subscribe_called());
+        assert_eq!(subscriber.get_received_states().len(), 1);
+        assert_eq!(subscriber.get_received_states()[0].counter, 10);
+
+        // 두 번째 on_subscribe 호출 (이미 subscribe_called가 true이므로 상태만 추가됨)
+        subscriber.on_subscribe(&state2);
+        assert!(subscriber.was_subscribe_called());
+        assert_eq!(subscriber.get_received_states().len(), 2);
+        assert_eq!(subscriber.get_received_states()[1].counter, 20);
+    }
+
+    // on_unsubscribe 기본 구현 테스트
+    #[test]
+    fn test_default_on_unsubscribe() {
+        let subscriber = TestSubscriberWithSubscribe::new();
+
+        // on_unsubscribe는 기본적으로 아무것도 하지 않음
+        subscriber.on_unsubscribe();
+
+        // subscriber의 상태가 변경되지 않았는지 확인
+        assert!(!subscriber.was_subscribe_called());
+        assert_eq!(subscriber.get_received_states().len(), 0);
+        assert_eq!(subscriber.get_received_actions().len(), 0);
+    }
+
+    // 복잡한 상태와 액션을 사용한 테스트
+    #[test]
+    fn test_complex_state_and_action() {
+        let subscriber = TestSubscriberWithSubscribe::new();
+
+        // 복잡한 상태
+        let complex_state = TestState {
+            counter: 999,
+            name: "complex_test_state".to_string(),
+        };
+
+        // 복잡한 액션
+        let complex_action = TestAction::SetName("new_name".to_string());
+
+        // on_subscribe 호출
+        subscriber.on_subscribe(&complex_state);
+
+        // on_notify 호출
+        subscriber.on_notify(&complex_state, &complex_action);
+
+        // 검증
+        assert!(subscriber.was_subscribe_called());
+        let states = subscriber.get_received_states();
+        let actions = subscriber.get_received_actions();
+
+        assert_eq!(states.len(), 2); // on_subscribe + on_notify
+        assert_eq!(actions.len(), 1); // on_notify만
+
+        assert_eq!(states[0].counter, 999);
+        assert_eq!(states[0].name, "complex_test_state");
+        assert_eq!(states[1].counter, 999);
+        assert_eq!(states[1].name, "complex_test_state");
+
+        match &actions[0] {
+            TestAction::SetName(name) => assert_eq!(name, "new_name"),
+            _ => panic!("Expected SetName action"),
+        }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,282 @@
+use rs_store::{DispatchOp, StoreBuilder};
+use rs_store::{Reducer, Subscriber};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+enum TestAction {
+    Increment,
+    Decrement,
+    SetValue(i32),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct TestState {
+    counter: i32,
+    name: String,
+}
+
+impl Default for TestState {
+    fn default() -> Self {
+        TestState {
+            counter: 0,
+            name: "default".to_string(),
+        }
+    }
+}
+
+struct TestReducer;
+
+impl Reducer<TestState, TestAction> for TestReducer {
+    fn reduce(&self, state: &TestState, action: &TestAction) -> DispatchOp<TestState, TestAction> {
+        match action {
+            TestAction::Increment => {
+                let new_state = TestState {
+                    counter: state.counter + 1,
+                    name: state.name.clone(),
+                };
+                DispatchOp::Dispatch(new_state, None)
+            }
+            TestAction::Decrement => {
+                let new_state = TestState {
+                    counter: state.counter - 1,
+                    name: state.name.clone(),
+                };
+                DispatchOp::Dispatch(new_state, None)
+            }
+            TestAction::SetValue(value) => {
+                let new_state = TestState {
+                    counter: *value,
+                    name: state.name.clone(),
+                };
+                DispatchOp::Dispatch(new_state, None)
+            }
+        }
+    }
+}
+
+struct IntegrationTestSubscriber {
+    id: String,
+    received_states: Arc<Mutex<Vec<TestState>>>,
+    received_actions: Arc<Mutex<Vec<TestAction>>>,
+    subscribe_called: Arc<Mutex<bool>>,
+    initial_state: Arc<Mutex<Option<TestState>>>,
+}
+
+#[allow(dead_code)]
+impl IntegrationTestSubscriber {
+    fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            received_states: Arc::new(Mutex::new(Vec::new())),
+            received_actions: Arc::new(Mutex::new(Vec::new())),
+            subscribe_called: Arc::new(Mutex::new(false)),
+            initial_state: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn get_received_states(&self) -> Vec<TestState> {
+        self.received_states.lock().unwrap().clone()
+    }
+
+    fn get_received_actions(&self) -> Vec<TestAction> {
+        self.received_actions.lock().unwrap().clone()
+    }
+
+    fn was_subscribe_called(&self) -> bool {
+        *self.subscribe_called.lock().unwrap()
+    }
+
+    fn get_initial_state(&self) -> Option<TestState> {
+        self.initial_state.lock().unwrap().clone()
+    }
+}
+
+impl Subscriber<TestState, TestAction> for IntegrationTestSubscriber {
+    fn on_subscribe(&self, state: &TestState) {
+        println!("[{}] on_subscribe called with state: {:?}", self.id, state);
+        *self.subscribe_called.lock().unwrap() = true;
+        *self.initial_state.lock().unwrap() = Some(state.clone());
+        self.received_states.lock().unwrap().push(state.clone());
+    }
+
+    fn on_notify(&self, state: &TestState, action: &TestAction) {
+        println!(
+            "[{}] on_notify called with state: {:?}, action: {:?}",
+            self.id, state, action
+        );
+        self.received_states.lock().unwrap().push(state.clone());
+        self.received_actions.lock().unwrap().push(action.clone());
+    }
+}
+
+#[test]
+fn test_integration_new_subscriber_feature() {
+    println!("=== Integration Test: New Subscriber Feature ===");
+
+    // Store 생성
+    let store = StoreBuilder::new_with_reducer(TestState::default(), Box::new(TestReducer))
+        .with_name("integration-test".into())
+        .build()
+        .unwrap();
+
+    // 첫 번째 subscriber 추가
+    println!("Adding first subscriber...");
+    let subscriber1 = Arc::new(IntegrationTestSubscriber::new("subscriber-1"));
+    store.add_subscriber(subscriber1.clone());
+
+    // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
+    thread::sleep(Duration::from_millis(100));
+
+    // 첫 번째 subscriber가 초기 상태를 받았는지 확인
+    assert!(subscriber1.was_subscribe_called());
+    assert_eq!(subscriber1.get_received_states().len(), 1);
+    assert_eq!(subscriber1.get_received_states()[0].counter, 0);
+
+    // 액션들을 dispatch하여 상태 변경
+    println!("Dispatching actions...");
+    store.dispatch(TestAction::Increment).unwrap();
+    store.dispatch(TestAction::Increment).unwrap();
+    store.dispatch(TestAction::SetValue(10)).unwrap();
+
+    // 잠시 대기하여 액션이 처리되도록 함
+    thread::sleep(Duration::from_millis(100));
+
+    // 첫 번째 subscriber가 모든 상태 변경을 받았는지 확인
+    let states1 = subscriber1.get_received_states();
+    let actions1 = subscriber1.get_received_actions();
+    assert_eq!(states1.len(), 4); // on_subscribe + 3 actions
+    assert_eq!(actions1.len(), 3); // 3 actions
+    assert_eq!(states1[1].counter, 1); // 첫 번째 Increment
+    assert_eq!(states1[2].counter, 2); // 두 번째 Increment
+    assert_eq!(states1[3].counter, 10); // SetValue(10)
+
+    // 두 번째 subscriber 추가 (현재 상태는 counter: 10)
+    println!("Adding second subscriber...");
+    let subscriber2 = Arc::new(IntegrationTestSubscriber::new("subscriber-2"));
+    store.add_subscriber(subscriber2.clone());
+
+    // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
+    thread::sleep(Duration::from_millis(100));
+
+    // 두 번째 subscriber가 현재 상태를 받았는지 확인
+    assert!(subscriber2.was_subscribe_called());
+    assert_eq!(subscriber2.get_received_states().len(), 1);
+    assert_eq!(subscriber2.get_received_states()[0].counter, 10);
+
+    // 새로운 액션을 dispatch
+    println!("Dispatching more actions...");
+    store.dispatch(TestAction::Decrement).unwrap();
+    store.dispatch(TestAction::Increment).unwrap();
+
+    // 잠시 대기하여 액션이 처리되도록 함
+    thread::sleep(Duration::from_millis(100));
+
+    // 두 subscriber 모두 새로운 액션을 받았는지 확인
+    let states1_final = subscriber1.get_received_states();
+    let states2_final = subscriber2.get_received_states();
+
+    assert_eq!(states1_final.len(), 6); // on_subscribe + 5 actions
+    assert_eq!(states2_final.len(), 3); // on_subscribe + 2 actions
+
+    assert_eq!(states1_final[4].counter, 9); // Decrement
+    assert_eq!(states1_final[5].counter, 10); // Increment
+
+    assert_eq!(states2_final[1].counter, 9); // Decrement
+    assert_eq!(states2_final[2].counter, 10); // Increment
+
+    println!("Integration test completed successfully!");
+}
+
+#[test]
+fn test_integration_concurrent_subscribers() {
+    println!("=== Integration Test: Concurrent Subscribers ===");
+
+    let store = StoreBuilder::new_with_reducer(TestState::default(), Box::new(TestReducer))
+        .with_name("concurrent-test".into())
+        .build()
+        .unwrap();
+
+    // 여러 스레드에서 동시에 subscriber 추가
+    let mut handles = vec![];
+    let store_clone = store.clone();
+
+    for i in 0..5 {
+        let store_thread = store_clone.clone();
+        let handle = thread::spawn(move || {
+            let subscriber = Arc::new(IntegrationTestSubscriber::new(&format!("thread-{}", i)));
+            store_thread.add_subscriber(subscriber.clone());
+
+            // 잠시 대기
+            thread::sleep(Duration::from_millis(50));
+
+            // 액션 dispatch
+            store_thread.dispatch(TestAction::Increment).unwrap();
+
+            subscriber
+        });
+        handles.push(handle);
+    }
+
+    // 모든 스레드 완료 대기
+    let subscribers: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // 잠시 대기하여 모든 액션이 처리되도록 함
+    thread::sleep(Duration::from_millis(200));
+
+    // 모든 subscriber가 정상적으로 작동했는지 확인
+    for subscriber in &subscribers {
+        assert!(subscriber.was_subscribe_called());
+        let states = subscriber.get_received_states();
+        let actions = subscriber.get_received_actions();
+
+        // 최소한 on_subscribe와 하나의 액션을 받았어야 함
+        assert!(states.len() >= 2);
+        assert!(actions.len() >= 1);
+    }
+
+    println!("Concurrent subscribers test completed successfully!");
+}
+
+#[test]
+fn test_integration_subscriber_lifecycle() {
+    println!("=== Integration Test: Subscriber Lifecycle ===");
+
+    let store = StoreBuilder::new_with_reducer(TestState::default(), Box::new(TestReducer))
+        .with_name("lifecycle-test".into())
+        .build()
+        .unwrap();
+
+    // subscriber 추가
+    let subscriber = Arc::new(IntegrationTestSubscriber::new("lifecycle"));
+    let subscription = store.add_subscriber(subscriber.clone());
+
+    // 잠시 대기
+    thread::sleep(Duration::from_millis(100));
+
+    // 초기 상태 확인
+    assert!(subscriber.was_subscribe_called());
+    assert_eq!(subscriber.get_received_states().len(), 1);
+
+    // 액션 dispatch
+    store.dispatch(TestAction::Increment).unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    // 액션 수신 확인
+    assert_eq!(subscriber.get_received_states().len(), 2);
+    assert_eq!(subscriber.get_received_actions().len(), 1);
+
+    // unsubscribe
+    subscription.unsubscribe();
+
+    // 추가 액션 dispatch
+    store.dispatch(TestAction::Increment).unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    // unsubscribe 후에는 액션을 받지 않아야 함
+    assert_eq!(subscriber.get_received_states().len(), 2);
+    assert_eq!(subscriber.get_received_actions().len(), 1);
+
+    println!("Subscriber lifecycle test completed successfully!");
+}


### PR DESCRIPTION

- Add ActionOp::AddSubscriber to handle new subscriber registration
- Add on_subscribe method to Subscriber trait for initial state delivery
- Add comprehensive test coverage for new subscriber functionality

This ensures new subscribers receive the current store state immediately upon subscription, rather than waiting for the next action dispatch.