### PR TITLE
feat: improve add_subscriber error handling and API consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ For detailed documentation, visit:
 ### In Progress 🚧
 - [x] Latest state notification for new subscribers
 - [x] Notification scheduler (CurrentThread, ThreadPool)
-- [X] Stream-based pull model(Iterator)
 - [ ] Stop store after all effects are scheduled
-- [X] Separate state interface and implementation
 - [X] drop store after all references are dropped
+- [x] dispatcher has weak reference to the store
+- [ ] effects system
 
 ## Contributing
 

--- a/examples/calc_basic.rs
+++ b/examples/calc_basic.rs
@@ -101,7 +101,7 @@ pub fn main() {
     .unwrap();
 
     println!("add subscriber");
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     store.dispatch(CalcAction::Add(1)).expect("no dispatch failed");
     store.dispatch(CalcAction::Subtract(1)).expect("no dispatch failed");
 

--- a/examples/calc_basic_builder.rs
+++ b/examples/calc_basic_builder.rs
@@ -100,12 +100,12 @@ pub fn main() {
             .build()
             .unwrap();
     println!("add subscriber");
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     let _ = store.dispatch(CalcAction::Add(1)).expect("no dispatch failed");
 
     thread::sleep(std::time::Duration::from_secs(1));
     println!("add more subscriber");
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     let _ = store.dispatch(CalcAction::Subtract(1));
 
     // stop the store

--- a/examples/calc_concurrent.rs
+++ b/examples/calc_concurrent.rs
@@ -114,7 +114,7 @@ pub fn main() {
             .unwrap();
 
     println!("add subscriber");
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     let _ = store.dispatch(CalcAction::Add(1));
 
     let store_clone = store.clone();
@@ -122,7 +122,7 @@ pub fn main() {
         thread::sleep(std::time::Duration::from_secs(1));
 
         println!("add more subscriber");
-        store_clone.add_subscriber(Arc::new(CalcSubscriber::new(1)));
+        store_clone.add_subscriber(Arc::new(CalcSubscriber::new(1))).unwrap();
         let _ = store_clone.dispatch(CalcAction::Subtract(1));
     })
     .join()

--- a/examples/calc_effect.rs
+++ b/examples/calc_effect.rs
@@ -130,7 +130,7 @@ pub fn main() {
             .build()
             .unwrap();
 
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     let _ = store.dispatch(CalcAction::AddWillProduceThunk(1));
 
     match store.stop() {

--- a/examples/calc_fn_basic.rs
+++ b/examples/calc_fn_basic.rs
@@ -66,11 +66,11 @@ pub fn main() {
     .build()
     .unwrap();
 
-    store.add_subscriber(Arc::new(FnSubscriber::from(calc_subscriber)));
+    store.add_subscriber(Arc::new(FnSubscriber::from(calc_subscriber))).unwrap();
     let _ = store.dispatch(CalcAction::Add(1));
 
     thread::sleep(std::time::Duration::from_secs(1));
-    store.add_subscriber(Arc::new(FnSubscriber::from(calc_subscriber)));
+    store.add_subscriber(Arc::new(FnSubscriber::from(calc_subscriber))).unwrap();
     let _ = store.dispatch(CalcAction::Subtract(1));
 
     match store.stop() {

--- a/examples/calc_new_subscriber.rs
+++ b/examples/calc_new_subscriber.rs
@@ -117,7 +117,7 @@ pub fn main() {
     // 첫 번째 subscriber 추가
     println!("=== Adding first subscriber ===");
     let subscriber1 = Arc::new(CalcSubscriberWithSubscribe::new(1));
-    store.add_subscriber(subscriber1.clone());
+    store.add_subscriber(subscriber1.clone()).unwrap();
 
     // 액션을 dispatch하여 상태 변경
     println!("=== Dispatching actions ===");
@@ -130,7 +130,7 @@ pub fn main() {
     // 두 번째 subscriber 추가 (현재 상태는 count: 15)
     println!("=== Adding second subscriber ===");
     let subscriber2 = Arc::new(CalcSubscriberWithSubscribe::new(2));
-    store.add_subscriber(subscriber2.clone());
+    store.add_subscriber(subscriber2.clone()).unwrap();
 
     // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
     thread::sleep(std::time::Duration::from_millis(100));

--- a/examples/calc_thunk.rs
+++ b/examples/calc_thunk.rs
@@ -138,7 +138,7 @@ pub fn main() {
     )
     .unwrap();
 
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     store.dispatch(CalcAction::Add(1)).expect("no dispatch failed");
 
     // send thunk to store

--- a/examples/calc_unsubscribe.rs
+++ b/examples/calc_unsubscribe.rs
@@ -114,7 +114,7 @@ pub fn main() {
             .unwrap();
 
     println!("add subscriber");
-    store.add_subscriber(Arc::new(CalcSubscriber::default()));
+    store.add_subscriber(Arc::new(CalcSubscriber::default())).unwrap();
     let _ = store.dispatch(CalcAction::Add(1));
 
     let store_clone = store.clone();
@@ -123,7 +123,7 @@ pub fn main() {
 
         // subscribe
         println!("add more subscriber");
-        let subscription = store_clone.add_subscriber(Arc::new(CalcSubscriber::new(1)));
+        let subscription = store_clone.add_subscriber(Arc::new(CalcSubscriber::new(1))).unwrap();
         let _ = store_clone.dispatch(CalcAction::Subtract(1));
         subscription
     });

--- a/examples/dropoldest_if.rs
+++ b/examples/dropoldest_if.rs
@@ -31,9 +31,11 @@ fn main() {
         .unwrap();
 
     // subscriber 추가
-    store.add_subscriber(Arc::new(FnSubscriber::from(|state: &i32, action: &i32| {
-        println!("subscriber: state: {}, action: {}", state, action);
-    })));
+    store
+        .add_subscriber(Arc::new(FnSubscriber::from(|state: &i32, action: &i32| {
+            println!("subscriber: state: {}, action: {}", state, action);
+        })))
+        .unwrap();
 
     println!("=== Predicate 기반 Backpressure 테스트 ===");
     println!("채널 capacity: 2");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,11 +12,13 @@ pub fn main() {
         .unwrap();
 
     // add subscriber
-    store.add_subscriber(Arc::new(FnSubscriber::from(
-        |state: &i32, _action: &i32| {
-            println!("subscriber: state: {}", state);
-        },
-    )));
+    store
+        .add_subscriber(Arc::new(FnSubscriber::from(
+            |state: &i32, _action: &i32| {
+                println!("subscriber: state: {}", state);
+            },
+        )))
+        .unwrap();
 
     // dispatch actions
     store.dispatch(41).expect("no error");

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -108,7 +108,7 @@ mod tests {
         let subscriber = Arc::new(TestSubscriber {
             state_changes: state_changes_clone,
         });
-        store.add_subscriber(subscriber);
+        store.add_subscriber(subscriber).unwrap();
 
         // then
         // Test sequence of actions
@@ -261,7 +261,7 @@ mod tests {
         let subscriber = Arc::new(TestSubscriber {
             state_changes: state_changes_clone,
         });
-        store.add_subscriber(subscriber);
+        store.add_subscriber(subscriber).unwrap();
 
         // when
         store.dispatch(5).unwrap(); // Should change state

--- a/src/store.rs
+++ b/src/store.rs
@@ -44,7 +44,7 @@ where
     fn add_subscriber(
         &self,
         subscriber: Arc<dyn Subscriber<State, Action> + Send + Sync>,
-    ) -> Box<dyn Subscription>;
+    ) -> Result<Box<dyn Subscription>, StoreError>;
 
     /// Iterate over the store's state and action pairs
     //fn iter(&self) -> impl Iterator<Item = (State, Action)>;

--- a/src/store_impl.rs
+++ b/src/store_impl.rs
@@ -26,6 +26,8 @@ where
     Action(Action),
     /// AddSubscriber is used to add a subscriber to the store
     AddSubscriber,
+    // /// RemoveSubscriber is used to remove a subscriber from the store
+    // RemoveSubscriber(u64),
     /// Exit is used to exit the store and should not be dropped
     #[allow(dead_code)]
     Exit(Instant),
@@ -208,6 +210,12 @@ where
                         #[cfg(feature = "store-log")]
                         eprintln!("store: {} subscribers added", new_subscribers_len);
                     }
+
+                    // ActionOp::RemoveSubscriber(subscriber_id) => {
+                    //     rx_store.do_remove_subscriber(subscriber_id);
+                    //     #[cfg(feature = "store-log")]
+                    //     eprintln!("store: {} subscribers removed", subscriber_id);
+                    // }
                     ActionOp::Exit(_) => {
                         rx_store.on_close(action_received_at);
                         #[cfg(feature = "store-log")]
@@ -248,7 +256,7 @@ where
     pub fn add_subscriber(
         &self,
         subscriber: Arc<dyn Subscriber<State, Action> + Send + Sync>,
-    ) -> Box<dyn Subscription> {
+    ) -> Result<Box<dyn Subscription>, StoreError> {
         // SubscriberWithId로 래핑하여 unique ID 할당
         let subscriber_with_id = SubscriberWithId::new(subscriber);
         let subscriber_id = subscriber_with_id.id;
@@ -258,15 +266,36 @@ where
 
         // ActionOp::AddSubscriber 액션을 전달하여 reducer에서 처리하도록 함
         if let Some(tx) = self.dispatch_tx.lock().unwrap().as_ref() {
-            let _ = tx.send(ActionOp::AddSubscriber);
+            match tx.send(ActionOp::AddSubscriber) {
+                Ok(_) => {}
+                Err(_e) => {
+                    #[cfg(feature = "store-log")]
+                    eprintln!(
+                        "store: Error while sending add subscriber to dispatch channel: {:?}",
+                        _e
+                    );
+                    self.adding_subscribers.lock().unwrap().retain(|s| s.id != subscriber_id);
+                    return Err(StoreError::DispatchError(format!(
+                        "Error while sending add subscriber to dispatch channel: {:?}",
+                        _e
+                    )));
+                }
+            }
         }
 
         // disposer for the subscriber
         let subscribers = self.subscribers.clone();
         let adding_subscribers = self.adding_subscribers.clone();
-        Box::new(SubscriberSubscription {
+        let subscription = Box::new(SubscriberSubscription {
             subscriber_id, // Store the ID for comparison
             unsubscribe: Box::new(move |subscriber_id| {
+                // dispacher는 Arc<StoreImpl<State, Action>> 이므로 RemoveSubscriber action 을 사용할 수 없는 이유
+                // 그래서 직접 vector에서 제거한다.
+
+                // remove from adding_subscribers
+                let mut adding = adding_subscribers.lock().unwrap();
+                adding.retain(|s| s.id != subscriber_id); // Compare by ID
+
                 let mut subscribers = subscribers.lock().unwrap();
                 subscribers.retain(|s| {
                     let retain = s.id != subscriber_id; // Compare by ID
@@ -275,12 +304,10 @@ where
                     }
                     retain
                 });
-
-                // remove from adding_subscribers
-                let mut adding = adding_subscribers.lock().unwrap();
-                adding.retain(|s| s.id != subscriber_id); // Compare by ID
             }),
-        })
+        });
+
+        Ok(subscription)
     }
 
     /// clear all subscribers
@@ -531,6 +558,23 @@ where
         }
     }
 
+    #[allow(dead_code)]
+    fn do_remove_subscriber(&self, subscriber_id: u64) {
+        // remove from adding_subscribers
+        let mut adding_subscribers = self.adding_subscribers.lock().unwrap();
+        adding_subscribers.retain(|s| s.id != subscriber_id);
+
+        // remove from subscribers
+        let mut subscribers = self.subscribers.lock().unwrap();
+        subscribers.retain(|s| {
+            let retain = s.id != subscriber_id;
+            if !retain {
+                s.on_unsubscribe();
+            }
+            retain
+        });
+    }
+
     fn on_close(&self, action_received_at: Instant) {
         #[cfg(feature = "store-log")]
         eprintln!("store: on_close");
@@ -688,7 +732,7 @@ where
     /// the channel is rendezvous(capacity 1), the store will block on the channel until the subscriber consumes the state
     #[allow(dead_code)]
     #[doc(hidden)]
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (State, Action)> {
+    pub(crate) fn iter(&self) -> Result<impl Iterator<Item = (State, Action)>, StoreError> {
         self.iter_with(1, BackpressurePolicy::BlockOnFull)
     }
 
@@ -703,7 +747,7 @@ where
         &self,
         capacity: usize,
         policy: BackpressurePolicy<(State, Action)>,
-    ) -> impl Iterator<Item = (State, Action)> {
+    ) -> Result<impl Iterator<Item = (State, Action)>, StoreError> {
         let (iter_tx, iter_rx) = BackpressureChannel::<(State, Action)>::pair_with(
             "store_iter",
             capacity,
@@ -712,7 +756,7 @@ where
         );
 
         let subscription = self.add_subscriber(Arc::new(StateIteratorSubscriber::new(iter_tx)));
-        StateIterator::new(iter_rx, subscription)
+        Ok(StateIterator::new(iter_rx, subscription?))
     }
 
     /// subscribing to store updates in new context
@@ -780,7 +824,7 @@ where
         let channel_subscriber = Arc::new(ChanneledSubscriber::new(handle, tx));
         let subscription = self.add_subscriber(channel_subscriber.clone());
 
-        Ok(subscription)
+        subscription
     }
 
     fn subscribed_loop(
@@ -810,6 +854,7 @@ where
                     #[cfg(feature = "store-log")]
                     eprintln!("store: {} received AddSubscriber (ignored)", _name);
                 }
+
                 ActionOp::Exit(created_at) => {
                     metrics.action_executed(None, created_at.elapsed());
                     #[cfg(feature = "store-log")]
@@ -938,7 +983,7 @@ where
     fn add_subscriber(
         &self,
         subscriber: Arc<dyn Subscriber<State, Action> + Send + Sync>,
-    ) -> Box<dyn Subscription> {
+    ) -> Result<Box<dyn Subscription>, StoreError> {
         self.add_subscriber(subscriber)
     }
 
@@ -1141,7 +1186,7 @@ mod tests {
         // 첫 번째 subscriber 추가
         let received1 = Arc::new(Mutex::new(Vec::new()));
         let subscriber1 = Arc::new(TestChannelSubscriber::new(received1.clone()));
-        store.add_subscriber(subscriber1);
+        store.add_subscriber(subscriber1).unwrap();
 
         // 액션을 dispatch하여 상태 변경
         store.dispatch(5).unwrap();
@@ -1153,7 +1198,7 @@ mod tests {
         // 두 번째 subscriber 추가 (현재 상태는 15)
         let received2 = Arc::new(Mutex::new(Vec::new()));
         let subscriber2 = Arc::new(TestChannelSubscriber::new(received2.clone()));
-        store.add_subscriber(subscriber2);
+        store.add_subscriber(subscriber2).unwrap();
 
         // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
         thread::sleep(Duration::from_millis(100));
@@ -1210,7 +1255,7 @@ mod tests {
             subscribe_called: subscribe_called.clone(),
         });
 
-        store.add_subscriber(subscriber);
+        store.add_subscriber(subscriber).unwrap();
 
         // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
         thread::sleep(Duration::from_millis(100));
@@ -1244,7 +1289,7 @@ mod tests {
         ];
 
         for subscriber in &subscribers {
-            store.add_subscriber(subscriber.clone());
+            store.add_subscriber(subscriber.clone()).unwrap();
         }
 
         // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
@@ -1275,7 +1320,7 @@ mod tests {
         // subscriber 추가
         let received = Arc::new(Mutex::new(Vec::new()));
         let subscriber = Arc::new(TestChannelSubscriber::new(received.clone()));
-        let subscription = store.add_subscriber(subscriber);
+        let subscription = store.add_subscriber(subscriber).unwrap();
 
         // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
         thread::sleep(Duration::from_millis(100));
@@ -1310,7 +1355,7 @@ mod tests {
         // subscriber 추가 시도
         let received = Arc::new(Mutex::new(Vec::new()));
         let subscriber = Arc::new(TestChannelSubscriber::new(received.clone()));
-        let _subscription = store.add_subscriber(subscriber);
+        let _subscription = store.add_subscriber(subscriber).unwrap();
 
         // 잠시 대기
         thread::sleep(Duration::from_millis(100));
@@ -1350,7 +1395,7 @@ mod tests {
             subscribe_called: Arc::new(Mutex::new(false)),
         });
 
-        store.add_subscriber(subscriber.clone());
+        store.add_subscriber(subscriber.clone()).unwrap();
 
         // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
         thread::sleep(Duration::from_millis(100));
@@ -1375,7 +1420,7 @@ mod tests {
         // 첫 번째 subscriber 추가
         let received1 = Arc::new(Mutex::new(Vec::new()));
         let subscriber1 = Arc::new(TestChannelSubscriber::new(received1.clone()));
-        store.add_subscriber(subscriber1);
+        store.add_subscriber(subscriber1).unwrap();
 
         // 잠시 대기
         thread::sleep(Duration::from_millis(50));
@@ -1383,7 +1428,7 @@ mod tests {
         // 두 번째 subscriber 추가
         let received2 = Arc::new(Mutex::new(Vec::new()));
         let subscriber2 = Arc::new(TestChannelSubscriber::new(received2.clone()));
-        store.add_subscriber(subscriber2);
+        store.add_subscriber(subscriber2).unwrap();
 
         // 잠시 대기
         thread::sleep(Duration::from_millis(50));
@@ -1391,7 +1436,7 @@ mod tests {
         // 세 번째 subscriber 추가
         let received3 = Arc::new(Mutex::new(Vec::new()));
         let subscriber3 = Arc::new(TestChannelSubscriber::new(received3.clone()));
-        store.add_subscriber(subscriber3);
+        store.add_subscriber(subscriber3).unwrap();
 
         // 잠시 대기하여 모든 AddSubscriber 액션이 처리되도록 함
         thread::sleep(Duration::from_millis(100));
@@ -1421,7 +1466,7 @@ mod tests {
         let store = StoreImpl::new_with_reducer(0, Box::new(TestReducer)).unwrap();
 
         // when: create iterator and dispatch actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         // dispatch actions
         store.dispatch(10).expect("dispatch should succeed");
@@ -1445,7 +1490,7 @@ mod tests {
         let store = StoreImpl::new_with_reducer(0, Box::new(TestReducer)).unwrap();
 
         // when: create iterator without dispatching actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         // then: iterator should return None immediately
         // since no actions were dispatched, no state changes occurred
@@ -1505,7 +1550,7 @@ mod tests {
         .unwrap();
 
         // when: create iterator and dispatch actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         store.dispatch(ComplexAction::Add(10)).expect("dispatch should succeed");
         store
@@ -1556,7 +1601,7 @@ mod tests {
         let store = StoreImpl::new_with_reducer(0, Box::new(TestReducer)).unwrap();
 
         // when: create iterator and dispatch many actions quickly
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         // dispatch multiple actions
         for i in 1..=10 {
@@ -1618,7 +1663,7 @@ mod tests {
         .unwrap();
 
         // when: create iterator and dispatch actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         store.dispatch(5).expect("dispatch should succeed");
         store.dispatch(10).expect("dispatch should succeed");
@@ -1652,7 +1697,7 @@ mod tests {
         .unwrap();
 
         // when: create iterator and dispatch actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         store.dispatch(3).expect("dispatch should succeed"); // no effect
         store.dispatch(10).expect("dispatch should succeed"); // with effect
@@ -1682,7 +1727,7 @@ mod tests {
             .unwrap();
 
         // when: create iterator and dispatch actions
-        // let mut iter = store.iter();
+        // let mut iter = store.iter().unwrap();
 
         store.dispatch(5).expect("dispatch should succeed");
         store.dispatch(10).expect("dispatch should succeed");
@@ -1709,7 +1754,7 @@ mod tests {
         let store = StoreImpl::new_with_reducer(0, Box::new(TestReducer)).unwrap();
 
         // when: create iterator, dispatch actions, but stop store early
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         store.dispatch(5).expect("dispatch should succeed");
         store.dispatch(10).expect("dispatch should succeed");
@@ -1741,7 +1786,7 @@ mod tests {
         .unwrap();
 
         // when: create iterator with different capacity and policy
-        let mut iter = store.iter_with(1, BackpressurePolicy::BlockOnFull);
+        let mut iter = store.iter_with(1, BackpressurePolicy::BlockOnFull).unwrap();
 
         store.dispatch(5).expect("dispatch should succeed");
         store.dispatch(10).expect("dispatch should succeed");
@@ -1792,7 +1837,7 @@ mod tests {
         .unwrap();
 
         // when: create iterator and dispatch string actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         store.dispatch("hello".to_string()).expect("dispatch should succeed");
         store.dispatch(" world".to_string()).expect("dispatch should succeed");
@@ -1823,7 +1868,7 @@ mod tests {
         )
         .unwrap();
         // when: create iterator and dispatch actions
-        let mut iter = store.iter();
+        let mut iter = store.iter().unwrap();
 
         store.dispatch(5).expect("dispatch should succeed");
         store.dispatch(10).expect("dispatch should succeed");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -125,7 +125,7 @@ fn test_integration_new_subscriber_feature() {
     // 첫 번째 subscriber 추가
     println!("Adding first subscriber...");
     let subscriber1 = Arc::new(IntegrationTestSubscriber::new("subscriber-1"));
-    store.add_subscriber(subscriber1.clone());
+    store.add_subscriber(subscriber1.clone()).unwrap();
 
     // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
     thread::sleep(Duration::from_millis(200));
@@ -156,7 +156,7 @@ fn test_integration_new_subscriber_feature() {
     // 두 번째 subscriber 추가 (현재 상태는 counter: 10)
     println!("Adding second subscriber...");
     let subscriber2 = Arc::new(IntegrationTestSubscriber::new("subscriber-2"));
-    store.add_subscriber(subscriber2.clone());
+    store.add_subscriber(subscriber2.clone()).unwrap();
 
     // 잠시 대기하여 AddSubscriber 액션이 처리되도록 함
     thread::sleep(Duration::from_millis(100));
@@ -208,7 +208,7 @@ fn test_integration_concurrent_subscribers() {
         let store_thread = store_clone.clone();
         let handle = thread::spawn(move || {
             let subscriber = Arc::new(IntegrationTestSubscriber::new(&format!("thread-{}", i)));
-            store_thread.add_subscriber(subscriber.clone());
+            store_thread.add_subscriber(subscriber.clone()).unwrap();
 
             // 잠시 대기
             thread::sleep(Duration::from_millis(50));
@@ -253,7 +253,7 @@ fn test_integration_subscriber_lifecycle() {
 
     // subscriber 추가
     let subscriber = Arc::new(IntegrationTestSubscriber::new("lifecycle"));
-    let subscription = store.add_subscriber(subscriber.clone());
+    let subscription = store.add_subscriber(subscriber.clone()).unwrap();
 
     // 잠시 대기
     thread::sleep(Duration::from_millis(100));


### PR DESCRIPTION
- Change add_subscriber return type to Result<Box<dyn Subscription>, StoreError>
- Add proper error handling for dispatch channel failures during subscriber addition
- Improve subscriber cleanup order in unsubscribe mechanism

Breaking change: add_subscriber now returns Result instead of direct Subscription.
All existing code needs to handle the Result or use .unwrap() for quick fixes.