### PR TITLE
refactor: unify backpressure policies with conditional variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-store"
-# 2.8.0 add query state
-version = "2.8.0"
+# 2.9.0 refactor policy enums
+version = "2.9.0"
 edition = "2021"
 authors = ["Changju Lee", "Changju Lee<rookiecj@gmail.com>"]
 description = "Redux Store for Rust"

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ use rs_store::{BackpressurePolicy, StoreBuilder};
 use std::sync::Arc;
 
 // Create a predicate that drops low-priority messages
-let predicate = Arc::new(|value: &i32| {
+let predicate = Box::new( | value: & i32| {
         *value < 5 // 5보다 작은 값들은 drop
     });
 
-let policy = BackpressurePolicy::DropLatestIf { predicate };
+let policy = BackpressurePolicy::DropLatestIf(Some(predicate));
 
 let store = StoreBuilder::new(0)
     .with_capacity(3) // Small capacity to trigger backpressure

--- a/examples/calc_query_state.rs
+++ b/examples/calc_query_state.rs
@@ -97,8 +97,9 @@ fn main() {
     println!("=== Query State Example ===");
 
     // Create a store with initial state
-    let store_impl = StoreImpl::new_with_reducer(CalcState::default(), Box::new(CalcReducer::default()))
-        .unwrap();
+    let store_impl =
+        StoreImpl::new_with_reducer(CalcState::default(), Box::new(CalcReducer::default()))
+            .unwrap();
 
     // Dispatch some actions
     println!("Dispatching actions...");

--- a/examples/dropoldest_if.rs
+++ b/examples/dropoldest_if.rs
@@ -5,12 +5,12 @@ fn main() {
     // predicate 기반 drop 정책 사용 예시
     // 작은 값들을 우선적으로 drop하는 predicate
     // predicate는 이제 Action의 내용(T)에만 적용됩니다
-    let predicate = Arc::new(|value: &i32| {
+    let predicate = Box::new(|value: &i32| {
         println!("droppable {} ? {}", *value, *value < 5);
         *value < 5 // 5보다 작은 값들은 drop
     });
 
-    let policy = BackpressurePolicy::DropOldestIf { predicate };
+    let policy = BackpressurePolicy::DropOldestIf(Some(predicate));
 
     // 매우 작은 capacity로 store 생성하여 backpressure 상황 시뮬레이션
     let store = StoreBuilder::new(0)

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -31,14 +31,14 @@ where
 unsafe impl<State, Action> Send for WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + std::fmt::Debug + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static
+    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
 }
 
 unsafe impl<State, Action> Sync for WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + std::fmt::Debug + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static
+    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
 }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -181,7 +181,7 @@ mod tests {
         let (tx, rx) = BackpressureChannel::<(i32, i32)>::pair_with(
             "test",
             5,
-            BackpressurePolicy::DropOldest,
+            BackpressurePolicy::DropOldestIf(None),
             None,
         );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -564,7 +564,7 @@ mod tests {
             vec![Box::new(TestReducer)],
             "test".to_string(),
             5,
-            BackpressurePolicy::DropOldest,
+            BackpressurePolicy::DropOldestIf(None),
             vec![],
         )
         .unwrap();
@@ -599,7 +599,7 @@ mod tests {
             vec![Box::new(TestReducer)],
             "test".to_string(),
             2,
-            BackpressurePolicy::DropOldest,
+            BackpressurePolicy::DropOldestIf(None),
             vec![],
         )
         .unwrap();
@@ -628,6 +628,7 @@ mod tests {
     fn test_count_metrics_with_middleware() {
         // given
         let middleware = Arc::new(TestMiddleware::new("test"));
+        #[allow(deprecated)]
         let store = StoreImpl::new_with(
             0,
             vec![Box::new(TestReducer)],

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -359,11 +359,9 @@ mod tests {
                     // do async
                     // ReqAsync -> Response
                     let v = v.clone();
-                    dispatcher.dispatch_thunk(
-                        Box::new(move |dispatcher| {
-                            let _ = dispatcher.dispatch(MiddlewareAction::ResponseAsThis(v + 1));
-                        }),
-                    );
+                    dispatcher.dispatch_thunk(Box::new(move |dispatcher| {
+                        let _ = dispatcher.dispatch(MiddlewareAction::ResponseAsThis(v + 1));
+                    }));
                     // done action
                     return Ok(MiddlewareOp::DoneAction);
                 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -317,6 +317,7 @@ mod tests {
 
     #[test]
     fn test_store_builder_configurations() {
+        #[allow(deprecated)]
         let store = StoreBuilder::new(TestState::default())
             .with_reducer(Box::new(TestReducer))
             .with_name("custom-store".into())
@@ -457,8 +458,8 @@ mod tests {
         ));
 
         // 작은 용량과 DropLatestIf 정책으로 구독
-        let predicate = Arc::new(|(_, _, action): &(Instant, i32, i32)| *action < 5);
-        let policy = BackpressurePolicy::DropLatestIf { predicate };
+        let predicate = Box::new(|(_, _, action): &(Instant, i32, i32)| *action < 5);
+        let policy = BackpressurePolicy::DropLatestIf(Some(predicate));
         let subscription = store.subscribed_with(2, policy, subscriber).unwrap();
 
         // 채널을 가득 채우는 액션들을 빠르게 dispatch

--- a/src/store_impl.rs
+++ b/src/store_impl.rs
@@ -129,7 +129,7 @@ where
         let (tx, rx) = BackpressureChannel::<Action>::pair_with(
             "dispatch",
             capacity,
-            policy.clone(),
+            policy,
             Some(metrics.clone()),
         );
 
@@ -1175,7 +1175,8 @@ mod tests {
         let received_states = Arc::new(Mutex::new(Vec::new()));
         let subscriber1 = Box::new(TestChannelSubscriber::new(received_states.clone()));
         // Create channel
-        let subscription = store.subscribed_with(10, BackpressurePolicy::DropOldest, subscriber1);
+        let subscription =
+            store.subscribed_with(10, BackpressurePolicy::DropOldestIf(None), subscriber1);
 
         // Dispatch some actions
         store.dispatch(1).unwrap();
@@ -1213,7 +1214,8 @@ mod tests {
             Duration::from_millis(100),
         ));
         // Create channel with small capacity
-        let subscription = store.subscribed_with(1, BackpressurePolicy::DropOldest, subscriber);
+        let subscription =
+            store.subscribed_with(1, BackpressurePolicy::DropOldestIf(None), subscriber);
 
         // Fill the channel
         for i in 0..5 {
@@ -1246,7 +1248,8 @@ mod tests {
 
         let received = Arc::new(Mutex::new(Vec::new()));
         let subscriber1 = Box::new(TestChannelSubscriber::new(received.clone()));
-        let subscription = store.subscribed_with(10, BackpressurePolicy::DropOldest, subscriber1);
+        let subscription =
+            store.subscribed_with(10, BackpressurePolicy::DropOldestIf(None), subscriber1);
 
         // Dispatch some actions
         store.dispatch(1).unwrap();
@@ -1901,14 +1904,15 @@ mod tests {
     //             DispatchOp::Dispatch(state + action, None)
     //         })))
     //         .with_capacity(2)
-    //         .with_policy(BackpressurePolicy::DropOldest)
+    //         .with_policy(BackpressurePolicy::DropOldestIf(None))
     //         .build()
     //         .unwrap();
     //
     //     // when: create iterator with different capacity and policy
     //     let mut iter = store.iter_with(1, BackpressurePolicy::BlockOnFull);
     //
-    //     store.dispatch(5).expect("dispatch should succeed");
+    //     store.dispatch(5).expect("dispat
+    // ch should succeed");
     //     store.dispatch(10).expect("dispatch should succeed");
     //
     //     // then: iterator should work with custom capacity and policy


### PR DESCRIPTION
Deprecate DropOldest and DropLatest in favor of DropOldestIf(None) and DropLatestIf(None) for a more consistent API.

- Change DropOldestIf/DropLatestIf to tuple variants with Option
- Remove Clone trait from BackpressurePolicy
- Update all pattern matching and examples

BREAKING CHANGE: BackpressurePolicy no longer implements Clone