### PR TITLE
refactor: change Subscriber and do_notify to use ref parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rs-store"
-# 2.9.3 remove Debug trait from Action
-version = "3.0.0-alpha.2"
+version = "3.0.0"
 edition = "2021"
 authors = ["Changju Lee", "Changju Lee<rookiecj@gmail.com>"]
 description = "Redux Store for Rust"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rs-store = "2.9"
+rs-store = "3.0"
 ```
 
 ## Quick Start
@@ -44,7 +44,7 @@ pub fn main() {
     let store = StoreBuilder::new(0)
         .with_reducer(Box::new(FnReducer::from(|state: &i32, action: &i32| {
             println!("reducer: {} + {}", state, action);
-            DispatchOp::Dispatch(state + action, None)
+            DispatchOp::Dispatch(state + action, vec![])
         })))
         .build()
         .unwrap();
@@ -138,7 +138,7 @@ This means reducers can produce asynchronous operations.
 
 ```rust
 impl Reducer<CalcState, CalcAction> for CalcReducer {
-    fn reduce(&self, state: CalcState, action: CalcAction) -> DispatchOp<CalcState, CalcAction> {
+    fn reduce(&self, state: &CalcState, action: &CalcAction) -> DispatchOp<CalcState, CalcAction> {
         match action {
             CalcAction::AddWillProduceThunk(i) => {
                 println!("CalcReducer::reduce: + {}", i);
@@ -146,7 +146,7 @@ impl Reducer<CalcState, CalcAction> for CalcReducer {
                     CalcState {
                         count: state.count + i,
                     },
-                    Some(Effect::Thunk(subtract_effect_thunk(i))),
+                    vec![Effect::Thunk(subtract_effect_thunk(i))],
                 )
             }
         }
@@ -191,10 +191,10 @@ impl Reducer<MyState, MyAction> for MyReducer {
     fn reduce(&self, state: &MyState, action: &MyAction) -> DispatchOp<MyState, MyAction> {
         match action {
             MyAction::Increment => {
-                DispatchOp::Dispatch(MyState { counter: state.counter + 1 }, None)
+                DispatchOp::Dispatch(MyState { counter: state.counter + 1 }, vec![])
             }
             MyAction::Decrement => {
-                DispatchOp::Dispatch(MyState { counter: state.counter - 1 }, None)
+                DispatchOp::Dispatch(MyState { counter: state.counter - 1 }, vec![])
             }
         }
     }
@@ -205,14 +205,14 @@ struct MySubscriber {
 }
 
 impl Subscriber<MyState, MyAction> for MySubscriber {
-    fn on_subscribe(&self, state: &MyState) {
+    fn on_subscribe(&self, state: MyState) {
         // Called when the subscriber is first added to the store
         // Receives the current state immediately
         println!("New subscriber received initial state: {:?}", state);
         self.received_states.lock().unwrap().push(state.clone());
     }
 
-    fn on_notify(&self, state: &MyState, action: &MyAction) {
+    fn on_notify(&self, state: MyState, action: MyAction) {
         // Called when the state changes due to an action
         println!("State updated: {:?}", state);
         self.received_states.lock().unwrap().push(state.clone());
@@ -245,7 +245,7 @@ The metrics feature provides a way to collect metrics.
 
 For detailed documentation, visit:
 
-- [API Documentation (docs.rs)](https://docs.rs/rs-store/2.9.0/rs_store/)
+- [API Documentation (docs.rs)](https://docs.rs/rs-store/latest/rs_store/)
 - [Crate Page (crates.io)](https://crates.io/crates/rs-store)
 
 ## Implementation Status
@@ -256,7 +256,7 @@ For detailed documentation, visit:
 - [-] ~~Stop store after all effects are scheduled~~ (removed)
 - [X] drop store after all references are dropped
 - [x] dispatcher has weak reference to the store
-- [ ] effects system
+- [x] effects system
 
 ## Contributing
 

--- a/examples/calc_basic.rs
+++ b/examples/calc_basic.rs
@@ -67,7 +67,7 @@ impl Default for CalcSubscriber {
 }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         match action {
             CalcAction::Add(_i) => {
                 println!(

--- a/examples/calc_basic_builder.rs
+++ b/examples/calc_basic_builder.rs
@@ -67,7 +67,7 @@ impl Default for CalcSubscriber {
 }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         match action {
             CalcAction::Add(_i) => {
                 println!(

--- a/examples/calc_concurrent.rs
+++ b/examples/calc_concurrent.rs
@@ -78,7 +78,7 @@ impl CalcSubscriber {
 }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         match action {
             CalcAction::Add(_i) => {
                 println!(

--- a/examples/calc_effect.rs
+++ b/examples/calc_effect.rs
@@ -73,7 +73,7 @@ impl Default for CalcSubscriber {
 }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         match action {
             CalcAction::AddWillProduceThunk(_i) => {
                 println!(

--- a/examples/calc_fn_basic.rs
+++ b/examples/calc_fn_basic.rs
@@ -44,7 +44,7 @@ fn calc_reducer(state: &CalcState, action: &CalcAction) -> DispatchOp<CalcState,
     }
 }
 
-fn calc_subscriber(state: CalcState, action: CalcAction) {
+fn calc_subscriber(state: &CalcState, action: &CalcAction) {
     match action {
         CalcAction::Add(i) => {
             println!("CalcSubscriber::on_notify: state:{:?}, action:{}", state, i);

--- a/examples/calc_new_subscriber.rs
+++ b/examples/calc_new_subscriber.rs
@@ -82,7 +82,7 @@ impl CalcSubscriberWithSubscribe {
 }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriberWithSubscribe {
-    fn on_subscribe(&self, state: CalcState) {
+    fn on_subscribe(&self, state: &CalcState) {
         println!(
             "CalcSubscriber::on_subscribe: id:{}, received initial state: {:?}",
             self.id, state
@@ -92,7 +92,7 @@ impl Subscriber<CalcState, CalcAction> for CalcSubscriberWithSubscribe {
         *self.last.lock().unwrap() = state.clone();
     }
 
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         println!(
             "CalcSubscriber::on_notify: id:{}, state: {:?} <- last: {:?} + action: {:?}",
             self.id,

--- a/examples/calc_thunk.rs
+++ b/examples/calc_thunk.rs
@@ -78,7 +78,7 @@ impl Default for CalcSubscriber {
 // }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         match action {
             CalcAction::Add(_i) => {
                 println!(

--- a/examples/calc_unsubscribe.rs
+++ b/examples/calc_unsubscribe.rs
@@ -78,7 +78,7 @@ impl CalcSubscriber {
 }
 
 impl Subscriber<CalcState, CalcAction> for CalcSubscriber {
-    fn on_notify(&self, state: CalcState, action: CalcAction) {
+    fn on_notify(&self, state: &CalcState, action: &CalcAction) {
         match action {
             CalcAction::Add(_i) => {
                 println!(

--- a/examples/dropoldest_if.rs
+++ b/examples/dropoldest_if.rs
@@ -27,7 +27,7 @@ fn main() {
 
     // subscriber 추가
     store
-        .add_subscriber(Arc::new(FnSubscriber::from(|state: i32, action: i32| {
+        .add_subscriber(Arc::new(FnSubscriber::from(|state: &i32, action: &i32| {
             println!("subscriber: state: {}, action: {}", state, action);
         })))
         .unwrap();

--- a/examples/performance_state_size.rs
+++ b/examples/performance_state_size.rs
@@ -460,7 +460,7 @@ fn test_small_state() {
         DispatchOp::Dispatch(new_state, vec![])
     });
 
-    let subscriber = FnSubscriber::from(move |state: SmallState, _action: TestAction| {
+    let subscriber = FnSubscriber::from(move |state: &SmallState, _action: &TestAction| {
         let start = Instant::now();
         let _ = state.clone();
         let elapsed = start.elapsed();
@@ -498,7 +498,7 @@ fn test_medium_state() {
         DispatchOp::Dispatch(new_state, vec![])
     });
 
-    let subscriber = FnSubscriber::from(move |state: MediumState, _action: TestAction| {
+    let subscriber = FnSubscriber::from(move |state: &MediumState, _action: &TestAction| {
         let start = Instant::now();
         let _ = state.clone();
         let elapsed = start.elapsed();
@@ -536,7 +536,7 @@ fn test_large_state() {
         DispatchOp::Dispatch(new_state, vec![])
     });
 
-    let subscriber = FnSubscriber::from(move |state: LargeState, _action: TestAction| {
+    let subscriber = FnSubscriber::from(move |state: &LargeState, _action: &TestAction| {
         let start = Instant::now();
         let _ = state.clone();
         let elapsed = start.elapsed();
@@ -574,7 +574,7 @@ fn test_very_large_state() {
         DispatchOp::Dispatch(new_state, vec![])
     });
 
-    let subscriber = FnSubscriber::from(move |state: VeryLargeState, _action: TestAction| {
+    let subscriber = FnSubscriber::from(move |state: &VeryLargeState, _action: &TestAction| {
         let start = Instant::now();
         let _ = state.clone();
         let elapsed = start.elapsed();
@@ -622,7 +622,7 @@ fn test_very_large_state_with_arc() {
         DispatchOp::Dispatch(new_state, vec![])
     });
 
-    let subscriber = FnSubscriber::from(move |state: ArcVeryLargeState, _action: TestAction| {
+    let subscriber = FnSubscriber::from(move |state: &ArcVeryLargeState, _action: &TestAction| {
         let start = Instant::now();
         // Arc clone은 매우 빠름 (참조 카운트만 증가)
         let _ = state.clone();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,9 +13,11 @@ pub fn main() {
 
     // add subscriber
     store
-        .add_subscriber(Arc::new(FnSubscriber::from(|state: i32, _action: i32| {
-            println!("subscriber: state: {}", state);
-        })))
+        .add_subscriber(Arc::new(FnSubscriber::from(
+            |state: &i32, _action: &i32| {
+                println!("subscriber: state: {}", state);
+            },
+        )))
         .unwrap();
 
     // dispatch actions

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 pub struct StoreBuilder<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     name: String,
     state: State,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -3,7 +3,7 @@ use crate::{StoreError, StoreImpl};
 use std::sync::{Arc, Weak};
 
 /// Dispatcher dispatches actions to the store
-pub trait Dispatcher<Action: Send + Clone + std::fmt::Debug>: Send {
+pub trait Dispatcher<Action: Send + Clone>: Send {
     /// dispatch is used to dispatch an action to the store
     /// the action can be dropped if the store is full
     fn dispatch(&self, action: Action) -> Result<(), StoreError>;
@@ -22,7 +22,7 @@ pub trait Dispatcher<Action: Send + Clone + std::fmt::Debug>: Send {
 pub(crate) struct WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     store: Weak<StoreImpl<State, Action>>,
 }
@@ -31,21 +31,21 @@ where
 unsafe impl<State, Action> Send for WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
 }
 
 unsafe impl<State, Action> Sync for WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
 }
 
 impl<State, Action> WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     /// WeakDispatcher 생성자
     pub fn new(dispatcher: Arc<StoreImpl<State, Action>>) -> Self {
@@ -58,7 +58,7 @@ where
 impl<State, Action> Dispatcher<Action> for WeakDispatcher<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn dispatch(&self, action: Action) -> Result<(), StoreError> {
         // weak reference를 strong reference로 업그레이드 시도
@@ -93,7 +93,7 @@ where
 impl<State, Action> Dispatcher<Action> for Arc<StoreImpl<State, Action>>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn dispatch(&self, action: Action) -> Result<(), StoreError> {
         let sender = self.dispatch_tx.lock().unwrap();

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -140,7 +140,7 @@ mod tests {
     }
 
     impl Subscriber<TestState, TestAction> for TestSubscriber {
-        fn on_notify(&self, state: TestState, action: TestAction) {
+        fn on_notify(&self, state: &TestState, action: &TestAction) {
             self.states.lock().unwrap().push(state.clone());
             self.actions.lock().unwrap().push(action.clone());
         }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,7 +1,7 @@
-use std::time::Instant;
 use crate::channel::{ReceiverChannel, SenderChannel};
-use crate::{Subscriber, Subscription};
 use crate::store_impl::ActionOp;
+use crate::{Subscriber, Subscription};
+use std::time::Instant;
 
 /// StateIteratorSubscriber is a subscriber that sends state and action pairs to an iterator
 #[allow(dead_code)]
@@ -15,7 +15,7 @@ where
 impl<State, Action> Subscriber<State, Action> for StateIteratorSubscriber<(State, Action)>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn on_notify(&self, state: &State, action: &Action) {
         if let Some(iter_tx) = self.iter_tx.as_ref() {
@@ -71,7 +71,7 @@ where
 pub(crate) struct StateIterator<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     iter_rx: Option<ReceiverChannel<(State, Action)>>,
     /// subscription for StateSubscriber
@@ -81,7 +81,7 @@ where
 impl<State, Action> Iterator for StateIterator<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     type Item = (State, Action);
 
@@ -131,7 +131,7 @@ where
 impl<State, Action> Drop for StateIterator<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug,
+    Action: Send + Sync + Clone,
 {
     fn drop(&mut self) {
         if let Some(rx) = self.iter_rx.take() {
@@ -148,7 +148,7 @@ where
 impl<State, Action> StateIterator<State, Action>
 where
     State: Send + Sync + Clone + 'static,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     pub(crate) fn new(
         iter_rx: ReceiverChannel<(State, Action)>,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -17,9 +17,10 @@ where
     State: Send + Sync + Clone + 'static,
     Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
-    fn on_notify(&self, state: State, action: Action) {
+    fn on_notify(&self, state: &State, action: &Action) {
         if let Some(iter_tx) = self.iter_tx.as_ref() {
-            match iter_tx.send(ActionOp::Action((state, action))) {
+            // Clone needed for sending through channel
+            match iter_tx.send(ActionOp::Action((state.clone(), action.clone()))) {
                 Ok(_) => {}
                 Err(_e) => {
                     #[cfg(feature = "store-log")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -532,7 +532,7 @@ mod tests {
     impl<State, Action> MiddlewareFnFactory<State, Action> for TestMiddleware
     where
         State: Send + Sync + Clone + 'static,
-        Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+        Action: Send + Sync + Clone + 'static,
     {
         fn create(&self, inner: MiddlewareFn<State, Action>) -> MiddlewareFn<State, Action> {
             Arc::new(move |state: &State, action: &Action| inner(state, action))

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -23,7 +23,7 @@ pub type MiddlewareFn<State, Action> = Arc<
 pub trait MiddlewareFnFactory<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn create(&self, inner: MiddlewareFn<State, Action>) -> MiddlewareFn<State, Action>;
 }

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -196,8 +196,8 @@ mod tests {
     }
 
     impl Subscriber<i32, i32> for TestSubscriber {
-        fn on_notify(&self, state: i32, _action: i32) {
-            self.state_changes.lock().unwrap().push(state);
+        fn on_notify(&self, state: &i32, _action: &i32) {
+            self.state_changes.lock().unwrap().push(*state);
         }
     }
 

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -21,7 +21,7 @@ pub enum DispatchOp<State, Action> {
 pub trait Reducer<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn reduce(&self, state: &State, action: &Action) -> DispatchOp<State, Action>;
 }
@@ -32,7 +32,7 @@ where
 pub struct ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + std::fmt::Debug + 'static,
+    Action: Send + Sync + 'static,
 {
     reducer: Arc<dyn Reducer<State, Action> + Send + Sync>,
     next: Option<Box<ReducerChain<State, Action>>>,
@@ -41,7 +41,7 @@ where
 impl<State, Action> ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + std::fmt::Debug + 'static,
+    Action: Send + Sync + 'static,
 {
     /// Create a new reducer chain with a single reducer
     pub fn new(reducer: Arc<dyn Reducer<State, Action> + Send + Sync>) -> Self {
@@ -85,7 +85,7 @@ where
 impl<State, Action> Clone for ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + std::fmt::Debug + 'static,
+    Action: Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
         Self {
@@ -98,7 +98,7 @@ where
 impl<State, Action> Reducer<State, Action> for ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn reduce(&self, state: &State, action: &Action) -> DispatchOp<State, Action> {
         // Execute current reducer
@@ -149,7 +149,7 @@ pub struct FnReducer<F, State, Action>
 where
     F: Fn(&State, &Action) -> DispatchOp<State, Action>,
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     func: F,
     _marker: std::marker::PhantomData<(State, Action)>,
@@ -159,7 +159,7 @@ impl<F, State, Action> Reducer<State, Action> for FnReducer<F, State, Action>
 where
     F: Fn(&State, &Action) -> DispatchOp<State, Action>,
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn reduce(&self, state: &State, action: &Action) -> DispatchOp<State, Action> {
         (self.func)(state, action)
@@ -170,7 +170,7 @@ impl<F, State, Action> From<F> for FnReducer<F, State, Action>
 where
     F: Fn(&State, &Action) -> DispatchOp<State, Action>,
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn from(func: F) -> Self {
         Self {

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -32,7 +32,7 @@ where
 pub struct ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + std::fmt::Debug + 'static,
 {
     reducer: Arc<dyn Reducer<State, Action> + Send + Sync>,
     next: Option<Box<ReducerChain<State, Action>>>,
@@ -41,7 +41,7 @@ where
 impl<State, Action> ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + std::fmt::Debug + 'static,
 {
     /// Create a new reducer chain with a single reducer
     pub fn new(reducer: Arc<dyn Reducer<State, Action> + Send + Sync>) -> Self {
@@ -79,16 +79,13 @@ where
 
         Some(tail)
     }
-
-    // Note: execute method removed as it's no longer used with the new API
-    // Reducer chain is now handled directly in the reduce method
 }
 
 // Implement Clone for ReducerChain to support recursive chaining
 impl<State, Action> Clone for ReducerChain<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + std::fmt::Debug + 'static,
 {
     fn clone(&self) -> Self {
         Self {

--- a/src/store.rs
+++ b/src/store.rs
@@ -120,7 +120,11 @@ mod tests {
     struct TestReducer;
 
     impl Reducer<TestState, TestAction> for TestReducer {
-        fn reduce(&self, state: &TestState, action: &TestAction) -> crate::DispatchOp<TestState, TestAction> {
+        fn reduce(
+            &self,
+            state: &TestState,
+            action: &TestAction,
+        ) -> crate::DispatchOp<TestState, TestAction> {
             match action {
                 TestAction::Increment => {
                     let mut new_state = state.clone();
@@ -172,9 +176,9 @@ mod tests {
     }
 
     impl Subscriber<i32, i32> for TestChannelSubscriber {
-        fn on_notify(&self, state: i32, action: i32) {
+        fn on_notify(&self, state: &i32, action: &i32) {
             //println!("TestChannelSubscriber: state={}, action={}", state, action);
-            self.received.lock().unwrap().push((state, action));
+            self.received.lock().unwrap().push((*state, *action));
         }
     }
 
@@ -190,10 +194,10 @@ mod tests {
     }
 
     impl Subscriber<i32, i32> for SlowSubscriber {
-        fn on_notify(&self, state: i32, action: i32) {
+        fn on_notify(&self, state: &i32, action: &i32) {
             //println!("SlowSubscriber: state={}, action={}", state, action);
             std::thread::sleep(self.delay);
-            self.received.lock().unwrap().push((state, action));
+            self.received.lock().unwrap().push((*state, *action));
         }
     }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -41,7 +41,7 @@ where
 impl<State, Action> SubscriberWithId<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     /// Create a new SubscriberWithId with auto-generated ID
     pub fn new(subscriber: Arc<dyn Subscriber<State, Action> + Send + Sync>) -> Self {
@@ -61,7 +61,7 @@ where
 impl<State, Action> Subscriber<State, Action> for SubscriberWithId<State, Action>
 where
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn on_subscribe(&self, state: &State) {
         self.subscriber.on_subscribe(state)
@@ -86,7 +86,7 @@ pub struct FnSubscriber<F, State, Action>
 where
     F: Fn(&State, &Action),
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     func: F,
     // error[E0392]: parameter `State` is never used
@@ -97,7 +97,7 @@ impl<F, State, Action> Subscriber<State, Action> for FnSubscriber<F, State, Acti
 where
     F: Fn(&State, &Action),
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn on_notify(&self, state: &State, action: &Action) {
         (self.func)(state, action)
@@ -108,7 +108,7 @@ impl<F, State, Action> From<F> for FnSubscriber<F, State, Action>
 where
     F: Fn(&State, &Action),
     State: Send + Sync + Clone,
-    Action: Send + Sync + Clone + std::fmt::Debug + 'static,
+    Action: Send + Sync + Clone + 'static,
 {
     fn from(func: F) -> Self {
         Self {

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -17,10 +17,10 @@ where
 {
     /// on_subscribe is called when the subscriber is subscribed to the store.
     #[allow(unused_variables)]
-    fn on_subscribe(&self, state: State) {}
+    fn on_subscribe(&self, state: &State) {}
 
     /// on_notify is called when the store is notified of an action.
-    fn on_notify(&self, state: State, action: Action);
+    fn on_notify(&self, state: &State, action: &Action);
 
     /// on_unsubscribe is called when a subscriber is unsubscribed from the store.
     fn on_unsubscribe(&self) {}
@@ -63,11 +63,11 @@ where
     State: Send + Sync + Clone,
     Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
-    fn on_subscribe(&self, state: State) {
+    fn on_subscribe(&self, state: &State) {
         self.subscriber.on_subscribe(state)
     }
 
-    fn on_notify(&self, state: State, action: Action) {
+    fn on_notify(&self, state: &State, action: &Action) {
         self.subscriber.on_notify(state, action)
     }
 
@@ -84,7 +84,7 @@ pub trait Subscription: Send {
 /// FnSubscriber is a subscriber that is created from a function.
 pub struct FnSubscriber<F, State, Action>
 where
-    F: Fn(State, Action),
+    F: Fn(&State, &Action),
     State: Send + Sync + Clone,
     Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
@@ -95,18 +95,18 @@ where
 
 impl<F, State, Action> Subscriber<State, Action> for FnSubscriber<F, State, Action>
 where
-    F: Fn(State, Action),
+    F: Fn(&State, &Action),
     State: Send + Sync + Clone,
     Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
-    fn on_notify(&self, state: State, action: Action) {
+    fn on_notify(&self, state: &State, action: &Action) {
         (self.func)(state, action)
     }
 }
 
 impl<F, State, Action> From<F> for FnSubscriber<F, State, Action>
 where
-    F: Fn(State, Action),
+    F: Fn(&State, &Action),
     State: Send + Sync + Clone,
     Action: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
@@ -170,16 +170,16 @@ mod tests {
     }
 
     impl Subscriber<TestState, TestAction> for TestSubscriberWithSubscribe {
-        fn on_subscribe(&self, state: TestState) {
+        fn on_subscribe(&self, state: &TestState) {
             // 새로운 subscriber가 추가될 때 최신 상태를 받음
-            self.received_states.lock().unwrap().push(state);
+            self.received_states.lock().unwrap().push(state.clone());
             *self.subscribe_called.lock().unwrap() = true;
         }
 
-        fn on_notify(&self, state: TestState, action: TestAction) {
+        fn on_notify(&self, state: &TestState, action: &TestAction) {
             // 액션이 발생할 때마다 상태와 액션을 받음
-            self.received_states.lock().unwrap().push(state);
-            self.received_actions.lock().unwrap().push(action);
+            self.received_states.lock().unwrap().push(state.clone());
+            self.received_actions.lock().unwrap().push(action.clone());
         }
     }
 
@@ -192,7 +192,7 @@ mod tests {
         };
 
         // on_subscribe 호출
-        subscriber.on_subscribe(state);
+        subscriber.on_subscribe(&state);
 
         // 검증
         assert!(subscriber.was_subscribe_called());
@@ -212,7 +212,7 @@ mod tests {
         let action = TestAction::IncrementCounter;
 
         // on_notify 호출
-        subscriber.on_notify(state, action);
+        subscriber.on_notify(&state, &action);
 
         // 검증
         let received_states = subscriber.get_received_states();
@@ -230,9 +230,9 @@ mod tests {
         let received_states = Arc::new(Mutex::new(Vec::new()));
         let received_actions = Arc::new(Mutex::new(Vec::new()));
 
-        let fn_subscriber = FnSubscriber::from(|state: TestState, action: TestAction| {
-            received_states.lock().unwrap().push(state);
-            received_actions.lock().unwrap().push(action);
+        let fn_subscriber = FnSubscriber::from(|state: &TestState, action: &TestAction| {
+            received_states.lock().unwrap().push(state.clone());
+            received_actions.lock().unwrap().push(action.clone());
         });
 
         let state = TestState {
@@ -242,7 +242,7 @@ mod tests {
         let action = TestAction::IncrementCounter;
 
         // on_notify 호출
-        fn_subscriber.on_notify(state, action);
+        fn_subscriber.on_notify(&state, &action);
 
         // 검증
         let states = received_states.lock().unwrap();
@@ -267,13 +267,13 @@ mod tests {
         };
 
         // 첫 번째 on_subscribe 호출
-        subscriber.on_subscribe(state1);
+        subscriber.on_subscribe(&state1);
         assert!(subscriber.was_subscribe_called());
         assert_eq!(subscriber.get_received_states().len(), 1);
         assert_eq!(subscriber.get_received_states()[0].counter, 10);
 
         // 두 번째 on_subscribe 호출 (이미 subscribe_called가 true이므로 상태만 추가됨)
-        subscriber.on_subscribe(state2);
+        subscriber.on_subscribe(&state2);
         assert!(subscriber.was_subscribe_called());
         assert_eq!(subscriber.get_received_states().len(), 2);
         assert_eq!(subscriber.get_received_states()[1].counter, 20);
@@ -308,10 +308,10 @@ mod tests {
         let complex_action = TestAction::SetName("new_name".to_string());
 
         // on_subscribe 호출
-        subscriber.on_subscribe(complex_state.clone());
+        subscriber.on_subscribe(&complex_state);
 
         // on_notify 호출
-        subscriber.on_notify(complex_state, complex_action);
+        subscriber.on_notify(&complex_state, &complex_action);
 
         // 검증
         assert!(subscriber.was_subscribe_called());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -94,14 +94,14 @@ impl IntegrationTestSubscriber {
 }
 
 impl Subscriber<TestState, TestAction> for IntegrationTestSubscriber {
-    fn on_subscribe(&self, state: TestState) {
+    fn on_subscribe(&self, state: &TestState) {
         // println!("[{}] on_subscribe called with state: {:?}", self.id, state);
         *self.subscribe_called.lock().unwrap() = true;
         *self.initial_state.lock().unwrap() = Some(state.clone());
         self.received_states.lock().unwrap().push(state.clone());
     }
 
-    fn on_notify(&self, state: TestState, action: TestAction) {
+    fn on_notify(&self, state: &TestState, action: &TestAction) {
         // println!(
         //     "[{}] on_notify called with state: {:?}, action: {:?}",
         //     self.id, state, action


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches notifications to pass `&State`/`&Action` to subscribers, removes `Debug` bounds from `Action` across core traits, and updates docs/examples; release 3.0.0.
> 
> - **API (breaking)**:
>   - Change `Subscriber` to use references: `on_subscribe(&State)` and `on_notify(&State, &Action)`.
>   - Update store internals to notify with refs (`do_notify`) and propagate ref flow end-to-end.
>   - Remove `std::fmt::Debug` bounds from `Action` in core traits/types (`Dispatcher`, `Reducer`, `MiddlewareFnFactory`, `StoreImpl`, iterators, etc.).
> - **Runtime/Internals**:
>   - Add non-`Debug` logging helpers (`describe_action`, `describe_action_op`); adjust error/log messages.
>   - Adapt channeled/iterator subscribers to clone only when sending through channels.
> - **Docs/Examples/Tests**:
>   - Update all examples, README, and tests to new `&State`/`&Action` signatures and new effects API usage.
>   - README: bump dependency to `rs-store = "3.0"`, docs link to `latest`, mark effects system complete.
> - **Release**:
>   - Bump crate version to `3.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f54e3557d1f2f6abe349b00952389ad10e0868d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->